### PR TITLE
change reference to ucr dir in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -179,7 +179,7 @@ extensions = [
         define_macros=def_macros,
    ),
    Extension(
-        "ucr_dtw.ucr", ["ucr-dtw/ucr.pyx"],
+        "ucr_dtw.ucr", ["ucr_dtw/ucr.pyx"],
         include_dirs = [numpy_path]
    )
 ]


### PR DESCRIPTION
Resolves issue #1 -- setup.py refers to ucr-dtw/ when ucr_dtw/ is the correct name.
