### PR TITLE
add direct link to blaze-dev mailinglist on google groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ $ python setup.py test
 Contributing
 ------------
 
-Anyone wishing to contribute should join the discussion on the mailing
-list at: blaze-dev@continuum.io
+Anyone wishing to contribute should join the discussion on the
+[blaze-dev](https://groups.google.com/a/continuum.io/forum/#!forum/blaze-dev)
+mailing list at: blaze-dev@continuum.io
 
 License
 -------


### PR DESCRIPTION
Wasn't clear to me how to subscribe to this list. Adding a direct link to list
archives on google groups should stop others from getting confused in the
future.
