### PR TITLE
Fix for getting an Array item

### DIFF
--- a/blaze/carray/carrayExtension.pyx
+++ b/blaze/carray/carrayExtension.pyx
@@ -1703,7 +1703,7 @@ cdef class carray:
         else:
           return arr1[0]
       # Fallback action: use the slice code
-      return np.squeeze(self[slice(key, None, 1)])
+      return np.squeeze(self[slice(key, key+1, 1)])
     # Slices
     elif isinstance(key, slice):
       (start, stop, step) = key.start, key.stop, key.step


### PR DESCRIPTION
Getting an Array by index will return the [idx:] instead.  Only occurs when carray.getitem_cache fails.

``` python

import blaze as blz
import numpy as np
shape = (366,624,1406)
a = np.arange(366*624*1406).reshape(shape)
b = blz.Array(a,dshape=blz.dshape('366,624,1406 int32'))
assert b[0].shape == (624,1406)
```
