### PR TITLE
Document Python dependencies for blaze

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -49,9 +49,11 @@ Dependencies
 * llvmpy_
 * ply_
 * python-blosc_
+* pycparser_
 
 .. _numpy: http://www.numpy.org/
 .. _cython: http://www.cython.org/
 .. _llvmpy: http://www.llvmpy.org/
 .. _ply: http://www.dabeaz.com/ply/
 .. _python-blosc: http://blosc.pytables.org
+.. _pycparser: https://bitbucket.org/eliben/pycparser


### PR DESCRIPTION
This is a partial fix for #58 that simply lists the Python modules required to run blaze. This is probably unnecessary if `setup.py` switches to using setuptools and `install_requires`.
