### PR TITLE
Out of core groupby example added

### DIFF
--- a/blaze/blz/btable.py
+++ b/blaze/blz/btable.py
@@ -463,6 +463,10 @@ class btable(object):
         # if len(newcol) != self.len:
         #     raise ValueError("`newcol` must have the same length than btable")
 
+        # The default is to persist columns if the table is persisted
+        if self.rootdir and 'rootdir' not in kwargs:
+            kwargs['rootdir'] = os.path.join(self.rootdir, name)
+
         if isinstance(newcol, np.ndarray):
             if 'bparams' not in kwargs:
                 kwargs['bparams'] = self.bparams

--- a/samples/ooc-groupby.py
+++ b/samples/ooc-groupby.py
@@ -7,6 +7,8 @@ import io
 import csv
 from dynd import nd, ndt
 from blaze import blz
+import os.path
+from shutil import rmtree
 
 
 # The toy CSV example
@@ -36,10 +38,8 @@ reader = csv.reader(io.StringIO(csvbuf))
 dname = 'persisted.blz'
 
 def maybe_remove(persist):
-    import os.path
     if os.path.exists(persist):
         # Remove every directory starting with rootdir
-        from shutil import rmtree
         rmtree(persist)
 
 
@@ -79,8 +79,9 @@ while True:
 
     prev_keys |= skeys
 
-# Finally, print the result (do not try to dump it in the traditional
-# way because the length of the columns is not the same)
+
+# Finally, print the ssby table (do not try to dump it in the
+# traditional way because the length of the columns is not the same)
 # print "ssby:", ssby
 for key in prev_keys:
     print "key:", key, ssby[key]


### PR DESCRIPTION
That requires slight modifications on the `blaze.blz.btable` object so that columns can have different lengths, but in the future perhaps a new object should be created instead (something like `blaze.blz.vltable`).

The new script in samples/ only deals with an in-memory CSV, but the algorithm should work for arbitrarily large CSV files on-disk.
