### PR TITLE
use relative imports for tests and blz_ext's use of bparams

### DIFF
--- a/blaze/io/blz/blz_ext.pyx
+++ b/blaze/io/blz/blz_ext.pyx
@@ -9,8 +9,8 @@
 
 import sys
 import numpy as np
-import blaze.io.blz as blz
-from blaze.io.blz import utils, attrs, array2string
+from . import utils, attrs, array2string
+from .bparams import bparams as blz_bparams
 import os, os.path
 import struct
 import shutil
@@ -992,9 +992,9 @@ cdef class barray:
 
     # Check defaults for bparams
     if bparams is None:
-      bparams = blz.bparams()
+      bparams = blz_bparams()
 
-    if not isinstance(bparams, blz.bparams):
+    if not isinstance(bparams, blz_bparams):
       raise ValueError, "`bparams` param must be an instance of `bparams` class"
 
     # Convert input to an appropriate type
@@ -1245,7 +1245,7 @@ cdef class barray:
       data = json.loads(storagefh.read().decode('ascii'))
     dtype_ = np.dtype(data["dtype"])
     chunklen = data["chunklen"]
-    bparams = blz.bparams(
+    bparams = blz_bparams(
       clevel = data["bparams"]["clevel"],
       shuffle = data["bparams"]["shuffle"])
     expectedlen = data["expectedlen"]

--- a/blaze/io/blz/tests/common.py
+++ b/blaze/io/blz/tests/common.py
@@ -3,7 +3,7 @@ import tempfile
 import os, os.path
 import glob
 import shutil
-from blaze.io import blz
+from ... import blz
 import numpy as np
 
 # Global variables for the tests

--- a/blaze/io/blz/tests/test_attrs.py
+++ b/blaze/io/blz/tests/test_attrs.py
@@ -7,8 +7,8 @@ import sys
 
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
-from blaze.io import blz
-from blaze.io.blz.tests import common
+from ... import blz
+from . import common
 
 class basicTest(common.MayBeDiskTest):
 

--- a/blaze/io/blz/tests/test_barray.py
+++ b/blaze/io/blz/tests/test_barray.py
@@ -10,8 +10,8 @@ from unittest import TestCase
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 
-from blaze.io import blz
-from blaze.io.blz.blz_ext import chunk
+from ... import blz
+from ..blz_ext import chunk
 from .common import MayBeDiskTest
 
 is_64bit = (struct.calcsize("P") == 8)

--- a/blaze/io/blz/tests/test_barray_objects.py
+++ b/blaze/io/blz/tests/test_barray_objects.py
@@ -16,7 +16,7 @@ from unittest import TestCase
 from numpy.testing.decorators import skipif, knownfailureif
 
 import numpy as np
-from blaze.io import blz
+from ... import blz
 from .common import MayBeDiskTest
 
 class ObjectBarrayTest(MayBeDiskTest, TestCase):

--- a/blaze/io/blz/tests/test_btable.py
+++ b/blaze/io/blz/tests/test_btable.py
@@ -15,7 +15,7 @@ from numpy.testing import assert_equal, assert_array_equal, assert_array_almost_
 from unittest import TestCase
 
 
-from blaze.io import blz
+from ... import blz
 from .common import MayBeDiskTest
 
 if sys.version_info >= (3, 0):

--- a/blaze/io/blz/tests/test_large_barray.py
+++ b/blaze/io/blz/tests/test_large_barray.py
@@ -7,12 +7,12 @@ from __future__ import absolute_import
 
 import sys
 from unittest import TestCase
-from blaze.py2help import skip
+from ....py2help import skip
 
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 
-from blaze.io import blz
+from ... import blz
 from .common import MayBeDiskTest
 
 

--- a/blaze/io/blz/tests/test_ndbarray.py
+++ b/blaze/io/blz/tests/test_ndbarray.py
@@ -13,7 +13,7 @@ import struct
 
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
-from blaze.io import blz
+from ... import blz
 from .common import MayBeDiskTest
 import unittest
 

--- a/blaze/io/blz/tests/test_queries.py
+++ b/blaze/io/blz/tests/test_queries.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 
-from blaze.io import blz
+from ... import blz
 
 if sys.version_info >= (3, 0):
     xrange = range

--- a/blaze/io/blz/tests/test_vtable.py
+++ b/blaze/io/blz/tests/test_vtable.py
@@ -15,7 +15,7 @@ from numpy.testing import (
     assert_equal, assert_array_equal, assert_array_almost_equal)
 from unittest import TestCase
 
-from blaze.io import blz
+from ... import blz
 from .common import MayBeDiskTest
 
 if sys.version_info >= (3, 0):


### PR DESCRIPTION
- modify the use of bparams in blz_ext to use a relative import to get at the
  class and import it as blz_bparams to minimize code changes throughout.
- use relative imports in tests to avoid namespace issues when building BLZ
  as a standalone package.
