### PR TITLE
blaze.array from iterator type deduction, closes issue #86

### DIFF
--- a/blaze/tests/test_array_creation.py
+++ b/blaze/tests/test_array_creation.py
@@ -13,20 +13,20 @@ class TestEphemeral(unittest.TestCase):
 
     def test_create_from_numpy(self):
         a = blaze.array(np.arange(3))
-        self.assert_(isinstance(a, blaze.Array))
+        self.assertTrue(isinstance(a, blaze.Array))
         self.assertEqual(dd_as_py(a._data), [0, 1, 2])
 
     def test_create(self):
         # A default array (backed by NumPy)
         a = blaze.array([1,2,3])
-        self.assert_(isinstance(a, blaze.Array))
+        self.assertTrue(isinstance(a, blaze.Array))
         self.assertEqual(dd_as_py(a._data), [1, 2, 3])
 
     @skip('A NotImplementedError should be raised')
     def test_create_append(self):
         # A default array (backed by NumPy, append not supported yet)
         a = blaze.array([])
-        self.assert_(isinstance(a, blaze.Array))
+        self.assertTrue(isinstance(a, blaze.Array))
         self.assertRaises(NotImplementedError, append, a, [1,2,3])
         # XXX The tests below still do not work
         # self.assertEqual(a[0], 1)
@@ -36,7 +36,7 @@ class TestEphemeral(unittest.TestCase):
     def test_create_compress(self):
         # A compressed array (backed by BLZ)
         a = blaze.array(np.arange(1,4), caps={'compress': True})
-        self.assert_(isinstance(a, blaze.Array))
+        self.assertTrue(isinstance(a, blaze.Array))
         self.assertEqual(dd_as_py(a._data), [1, 2, 3])
         # XXX The tests below still do not work
         # self.assertEqual(a[0], 1)
@@ -67,31 +67,31 @@ class TestEphemeral(unittest.TestCase):
     def test_create_compress_iter(self):
         # A compressed array (backed by BLZ)
         a = blaze.array((i for i in range(10)), caps={'compress': True})
-        self.assert_(isinstance(a, blaze.Array))
+        self.assertTrue(isinstance(a, blaze.Array))
         self.assertEqual(dd_as_py(a._data), list(range(10)))
 
     def test_create_zeros(self):
-        # A default array (backed by NumPy)
+        # A default array
         a = blaze.zeros('10, int64')
-        self.assert_(isinstance(a, blaze.Array))
+        self.assertTrue(isinstance(a, blaze.Array))
         self.assertEqual(dd_as_py(a._data), [0]*10)
 
     def test_create_compress_zeros(self):
         # A compressed array (backed by BLZ)
         a = blaze.zeros('10, int64', caps={'compress': True})
-        self.assert_(isinstance(a, blaze.Array))
+        self.assertTrue(isinstance(a, blaze.Array))
         self.assertEqual(dd_as_py(a._data), [0]*10)
 
     def test_create_ones(self):
-        # A default array (backed by NumPy)
+        # A default array
         a = blaze.ones('10, int64')
-        self.assert_(isinstance(a, blaze.Array))
+        self.assertTrue(isinstance(a, blaze.Array))
         self.assertEqual(dd_as_py(a._data), [1]*10)
 
     def test_create_compress_ones(self):
         # A compressed array (backed by BLZ)
         a = blaze.ones('10, int64', caps={'compress': True})
-        self.assert_(isinstance(a, blaze.Array))
+        self.assertTrue(isinstance(a, blaze.Array))
         self.assertEqual(dd_as_py(a._data), [1]*10)
 
     def test_create_record(self):
@@ -113,15 +113,15 @@ class TestPersistent(MayBeUriTest, unittest.TestCase):
     def test_create(self):
         persist = blaze.Storage(self.rooturi, format="blz")
         a = blaze.array([], 'float64', storage=persist)
-        self.assert_(isinstance(a, blaze.Array))
+        self.assertTrue(isinstance(a, blaze.Array))
         print("->", a.dshape.shape)
-        self.assert_(a.dshape.shape == (0,))
+        self.assertTrue(a.dshape.shape == (0,))
         self.assertEqual(dd_as_py(a._data), [])
 
     def test_append(self):
         persist = blaze.Storage(self.rooturi, format="blz")
         a = blaze.zeros('0, float64', storage=persist)
-        self.assert_(isinstance(a, blaze.Array))
+        self.assertTrue(isinstance(a, blaze.Array))
         append(a,list(range(10)))
         self.assertEqual(dd_as_py(a._data), list(range(10)))
 
@@ -129,7 +129,7 @@ class TestPersistent(MayBeUriTest, unittest.TestCase):
     def test_append2(self):
         persist = blaze.Storage(self.rooturi, format="blz")
         a = blaze.empty('0, 2, float64', storage=persist)
-        self.assert_(isinstance(a, blaze.Array))
+        self.assertTrue(isinstance(a, blaze.Array))
         lvals = [[i,i*2] for i in range(10)]
         append(a,lvals)
         self.assertEqual(dd_as_py(a._data), lvals)
@@ -140,7 +140,7 @@ class TestPersistent(MayBeUriTest, unittest.TestCase):
         append(a,range(10))
         # Re-open the dataset in URI
         a2 = blaze.open(persist)
-        self.assert_(isinstance(a2, blaze.Array))
+        self.assertTrue(isinstance(a2, blaze.Array))
         self.assertEqual(dd_as_py(a2._data), list(range(10)))
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add some simple tests that make sure the type is being deduced ok. The changes to make this possible have been pushed to dynd.
