### PR TITLE
Support for HDF5 in catalog

### DIFF
--- a/blaze/datadescriptor/tests/test_hdf5_data_descriptor.py
+++ b/blaze/datadescriptor/tests/test_hdf5_data_descriptor.py
@@ -85,8 +85,10 @@ class TestHDF5DataDescriptor(unittest.TestCase):
         tshape = '2, { f0 : int32; f1 : int64; f2 : float64 }'
         self.assertEqual(dd.dshape, datashape.dshape(tshape))
         dd.append([(10, 11, 12)])
-        vals = list(dd_as_py(dd[2]).values())
-        self.assertEqual(vals, [10, 11, 12])
+        dvals = {'f0': 10, 'f1': 11, 'f2': 12.}
+        rvals = dd_as_py(dd[2])
+        is_equal = [(rvals[k] == dvals[k]) for k in dvals]
+        self.assertEqual(is_equal, [True]*3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Here it is preliminary support for HDF5 datasets in catalog.  This is based in the previous HDF5 DataDescriptor PR.  So the later should be accepted before this can be merged.

This is ready for review now.
