### PR TITLE
missing whitespace in install documentation

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -33,6 +33,7 @@ To build project inside of Anaconda:
 To build documentation on a unix-based system:
 
 ::
+
     $ cd docs
     $ make docs
 


### PR DESCRIPTION
There was some missing whitespace in the installation instructions leading to some command line syntax not being rendered correctly.
