### PR TITLE
Support for HDF5 format in Storage class

### DIFF
--- a/blaze/io/storage.py
+++ b/blaze/io/storage.py
@@ -219,7 +219,7 @@ def from_json(persist, **kwargs):
     dd = JSONDataDescriptor(persist.path, **kwargs)
     return Array(dd)
 
-def from_hdf5(persist, **kwargs):
+def from_hdf5(persist, datapath, **kwargs):
     """Open an existing persistent HDF5 array.
 
     Parameters
@@ -236,7 +236,7 @@ def from_hdf5(persist, **kwargs):
 
     """
     persist = _persist_convert(persist)
-    dd = HDF5DataDescriptor(persist.path, **kwargs)
+    dd = HDF5DataDescriptor(persist.path, datapath, **kwargs)
     return Array(dd)
 
 def drop(persist):

--- a/blaze/tests/common.py
+++ b/blaze/tests/common.py
@@ -10,24 +10,25 @@ import glob
 
 
 # Useful superclass for disk-based tests
-class MayBeUriTest():
-
-    uri = False
+class PersistentTest():
 
     def setUp(self):
-        if self.uri:
+        if self.pformat == "blz":
             prefix = 'barray-' + self.__class__.__name__
-            self.rootdir = tempfile.mkdtemp(prefix=prefix)
-            self.rooturi = 'file://' + self.rootdir
-            os.rmdir(self.rootdir)  # tests needs this cleared
-        else:
-            self.rootdir = None
+            self.root = tempfile.mkdtemp(prefix=prefix)
+            os.rmdir(self.root)
+
+        elif self.pformat == "hdf5":
+            prefix = 'hdf5-' + self.__class__.__name__
+            _, self.root = tempfile.mkstemp(suffix='.h5', prefix=prefix)
+            os.remove(self.root)
 
     def tearDown(self):
-        if self.uri:
-            # Remove every directory starting with rootdir
-            for dir_ in glob.glob(self.rootdir+'*'):
+        if self.pformat == "blz":
+            for dir_ in glob.glob(self.root+'*'):
                 shutil.rmtree(dir_)
+        elif self.pformat == "hdf5":
+            os.remove(self.root)
 
 
 class BTestCase(unittest.TestCase):


### PR DESCRIPTION
This implements preliminary support for HDF5 format in Storage class.

Also, I think that, as HDF5 allows to store several datasets inside a file, the Storage constructor would require a new parameter to specify the dataset name inside the file.  I suggest using a new, optional, `datapath` parameter for that.

One of the tests fails due to
https://github.com/ContinuumIO/dynd-python/issues/51
