### PR TITLE
[WIP] allow JSON data descriptor to iterate over series of JSON files

### DIFF
--- a/blaze/datadescriptor/json_data_descriptor.py
+++ b/blaze/datadescriptor/json_data_descriptor.py
@@ -14,6 +14,43 @@ def json_descriptor_iter(array):
     for row in array:
         yield DyND_DDesc(row)
 
+def all_files_in_dir(a_path):
+    import os
+    for root, dirs, files in os.walk(a_path):
+        for f in files:
+            yield os.path.join(root,f)
+
+class Paths(object):
+    """
+    A small class that provides generator functionality over a bunch of files.
+    If you pass in something with files (either a list of files or a directory
+    containing a list of files) the Paths object will be iterable over those
+    files. If not, we assume we just have one file and make an iterable over that.
+    """
+    def __init__(self, paths):
+        try:
+            # If it's a file, make it iterable
+            import os
+            if (os.path.isfile(paths)):
+                self._paths = [paths]
+            elif (os.path.isdir(paths)):
+                self._paths = all_files_in_dir(paths)
+            else:
+                # test for iterability
+                _ = (p for p in paths)
+                self._paths = paths
+        except TypeError:
+            try:
+                # test for iterability
+                _ = (p for p in paths)
+                self._paths = paths
+            except TypeError:
+                raise ValueError("Don't know what kind of data this is!")
+
+    def __iter__(self):
+        for p in self._paths:
+            yield  p
+
 
 class JSON_DDesc(DDesc):
     """
@@ -21,16 +58,18 @@ class JSON_DDesc(DDesc):
 
     Parameters
     ----------
-    path : string
-        A path string for the JSON file.
+    pth : a filename, an iterable of filenames, or a directory
     schema : string or datashape
         A datashape (or its string representation) of the schema
         in the JSON file.
     """
-    def __init__(self, path, mode='r', **kwargs):
-        if os.path.isfile(path) is not True:
-            raise ValueError('JSON file "%s" does not exist' % path)
-        self.path = path
+    def __init__(self, pth, mode='r', **kwargs):
+        self.file_end = False
+        #Set the paths iterator
+        self._paths_iter = iter(Paths(pth))
+        self.cur_path = self.get_next_file()
+        if os.path.isfile(self.cur_path) is not True:
+            raise ValueError('JSON file "%s" does not exist' % self.cur_path)
         self.mode = mode
         schema = kwargs.get("schema", None)
         if type(schema) in py2help._strtypes:
@@ -42,6 +81,13 @@ class JSON_DDesc(DDesc):
     @property
     def dshape(self):
         return datashape.dshape(self.schema)
+
+    def get_next_file(self):
+        try:
+            return self._paths_iter.next()
+        except StopIteration:
+            self.file_end = True
+            return None
 
     @property
     def capabilities(self):
@@ -62,11 +108,15 @@ class JSON_DDesc(DDesc):
     def _arr_cache(self):
         if self._cache_arr is not None:
             return self._cache_arr
-        with open(self.path, mode=self.mode) as jsonfile:
-            # This will read everything in-memory (but a memmap approach
-            # is in the works)
-            self._cache_arr = nd.parse_json(
-                self.schema, jsonfile.read())
+        if (self.cur_path):
+            with open(self.cur_path, mode=self.mode) as jsonfile:
+                # This will read everything in-memory (but a memmap approach
+                # is in the works)
+                self._cache_arr = nd.parse_json(
+                    self.schema, jsonfile.read())
+            #Set up the next file, if there is one
+            self.cur_path = self.get_next_file()
+
         return self._cache_arr
 
     def dynd_arr(self):
@@ -87,7 +137,11 @@ class JSON_DDesc(DDesc):
         raise NotImplementedError
 
     def __iter__(self):
-        return json_descriptor_iter(self._arr_cache)
+        while (self._arr_cache is not None):
+            for row in self._arr_cache:
+                yield DyND_DDesc(row)
+            #done with that cache, reset
+            self._cache_arr = None
 
     def remove(self):
         """Remove the persistent storage."""


### PR DESCRIPTION
The JSON Data Descriptor can now take in a series of files. It does this by basically operating on a current file, and then having a mechanism to go to the next file. So, as an iterable, the datadescriptor goes over every file. But, if you just do something like:

``` Python
dd = JSON_DDesc([self.json_file, self.json_file2], schema=json_schema)
ddesc_as_py(dd)
```

You only get the stuff in the current file (in this case, the first file). So, the question that I have is whether or not asking for the full array should go and read every file given to the data descriptor constructor. Very interested in feedback.
