### PR TITLE
Updates for the type_tweaks in dynd

### DIFF
--- a/blaze/compute/air/execution/interp.py
+++ b/blaze/compute/air/execution/interp.py
@@ -27,7 +27,7 @@ def interpret(func, env, ddesc=None, **kwds):
 
         res_shape, res_dt = datashape.to_numpy(func.type.restype)
         dim_size = operator.index(res_shape[0])
-        row_size = ndt.type(str(func.type.restype.subarray(1))).data_size
+        row_size = ndt.type(str(func.type.restype.subarray(1))).default_data_size
         chunk_size = min(max(1, (1024*1024) // row_size), dim_size)
         # Evaluate by streaming the outermost dimension,
         # and using the BLZ data descriptor's append

--- a/blaze/datadescriptor/membuf_data_descriptor.py
+++ b/blaze/datadescriptor/membuf_data_descriptor.py
@@ -20,7 +20,8 @@ def data_descriptor_from_ctypes(cdata, writable):
     """
     ds = datashape.from_ctypes(type(cdata))
     access = "readwrite" if writable else "readonly"
-    dyndarr = _lowlevel.array_from_ptr(ndt.type(str(ds)),
+    dyndtp = ' * '.join(['cfixed[%d]' % int(x) for x in ds[:-1]] + [str(ds[-1])])
+    dyndarr = _lowlevel.array_from_ptr(ndt.type(dyndtp),
                     ctypes.addressof(cdata), cdata,
                     access)
     return DyND_DDesc(dyndarr)
@@ -51,6 +52,7 @@ def data_descriptor_from_cffi(ffi, cdata, writable):
         # size, get its size from the data
         ds = datashape.DataShape(*(datashape.Fixed(len(cdata)),) + ds[1:])
     access = "readwrite" if writable else "readonly"
-    dyndarr = _lowlevel.array_from_ptr(ndt.type(str(ds)), ptr, owner, access)
+    dyndtp = ' * '.join(['cfixed[%d]' % int(x) for x in ds[:-1]] + [str(ds[-1])])
+    dyndarr = _lowlevel.array_from_ptr(ndt.type(dyndtp), ptr, owner, access)
     return DyND_DDesc(dyndarr)
 


### PR DESCRIPTION
The PR from dynd includes a number of changes, most
notably adding a fixed_dim type which better matches
the fixed dimension of blaze.

https://github.com/ContinuumIO/libdynd/pull/30

https://github.com/ContinuumIO/dynd-python/pull/67
