### PR TITLE
Add compute(Expr, DataDescriptor) implementation

### DIFF
--- a/blaze/data/core.py
+++ b/blaze/data/core.py
@@ -152,3 +152,11 @@ class DataDescriptor(object):
             return self.dshape.subarray(1)
         raise TypeError('Datashape is not indexable to schema\n%s' %
                         self.dshape)
+
+
+from blaze.compute.python import dispatch
+from blaze.expr.table import Join, TableExpr
+from blaze.expr.core import Expr
+@dispatch((Join, Expr), DataDescriptor)
+def compute(t, ddesc):
+    return compute(t, iter(ddesc))  # use Python streaming by default

--- a/blaze/data/sql.py
+++ b/blaze/data/sql.py
@@ -196,3 +196,14 @@ class SQL(DataDescriptor):
             return next(result)
         else:
             return result
+
+
+# from blaze.expr.core import Expr
+from blaze.expr.table import Join, Expr
+from multipledispatch import dispatch
+@dispatch((Join, Expr), SQL)
+def compute(t, ddesc):
+    query = compute(t, ddesc.table)             # Get the query out
+    with ddesc.engine.connect() as conn:
+        result = conn.execute(query).fetchall() # Use SQLAlchemy to actually perform the query
+    return result

--- a/blaze/data/tests/test_csv.py
+++ b/blaze/data/tests/test_csv.py
@@ -257,6 +257,14 @@ class TestCSV(unittest.TestCase):
     def tearDown(self):
         os.remove(self.csv_file)
 
+    def test_compute(self):
+        dd = CSV(self.csv_file, schema=self.schema)
+
+        from blaze.expr.table import TableSymbol
+        from blaze.compute.python import compute
+        t = TableSymbol(self.schema)
+        self.assertEqual(compute(t['f2'].sum(), dd), 1 + 2 + 3)
+
     def test_has_header(self):
         assert not has_header(self.buf)
 


### PR DESCRIPTION
Previously we would do

```
results = compute(expr, iter(csv_ddesc))
```

or

```
query = compute(expr, sql_ddesc.table)
with sql_ddesc.engine.connect() as conn:
    results = conn.execute(query)
```

Now these are baked in so we just do

```
results = compute(expr, csv_ddesc)
results = compute(expr, sql_ddesc)
```

This is notationally convenient but organizationally tricky.

The left argument is from `blaze.expr`, the right is from `blaze.data`.
Historically these two haven't depended on each other.
