### PR TITLE
Compute fix

### DIFF
--- a/blaze/compute/pandas.py
+++ b/blaze/compute/pandas.py
@@ -23,6 +23,7 @@ from multipledispatch import dispatch
 import numpy as np
 
 from ..expr.table import *
+from . import core
 
 __all__ = ['compute']
 

--- a/blaze/compute/python.py
+++ b/blaze/compute/python.py
@@ -23,6 +23,7 @@ from ..expr.table import *
 from ..compatibility import builtins
 from .. import utils
 from ..utils import groupby, get, reduceby, unique
+from . import core
 
 __all__ = ['compute', 'Sequence']
 

--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -22,6 +22,7 @@ import sqlalchemy
 
 from blaze.expr.table import *
 from blaze.utils import unique
+from . import core
 
 __all__ = ['compute', 'computefull', 'select']
 


### PR DESCRIPTION
In using the compute mechanism, I found that I would often get NotImplemented exceptions. This was traced to the fact that the compute dispatcher was becoming aware of blaze/compute/core.py through fortunate imports in other code, and not from directly importing blaze/compute/pandas.py (or sql.py or similar). Therefore, we directory import core in each .py file in blaze/compute
