### PR TITLE
use instance for sqlalchemy type checking

### DIFF
--- a/blaze/data/sql.py
+++ b/blaze/data/sql.py
@@ -43,8 +43,10 @@ revtypes = dict(map(reversed, types.items()))
 
 revtypes.update({sql.types.VARCHAR: 'string',
                  sql.types.DATETIME: 'datetime',
+                 sql.types.TIMESTAMP: 'datetime',
                  sql.types.FLOAT: 'real',
                  sql.types.DATE: 'date',
+                 sql.types.BIGINT: 'int64',
                  sql.types.INTEGER: 'int'})
 
 
@@ -53,7 +55,10 @@ def discover(typ):
     if type(typ) in revtypes:
         return dshape(revtypes[type(typ)])[0]
     else:
-        raise NotImplementedError("No SQL-datashape match for type %s" % typ)
+        for k, v in revtypes.items():
+            if isinstance(typ, k):
+                return v
+    raise NotImplementedError("No SQL-datashape match for type %s" % typ)
 
 
 @dispatch(sql.Table)


### PR DESCRIPTION
Looks like sqlalchemy has a hierarchy for the various dtypes.  We use instance to help deal with this.  This was relevant when dealing with Postgres rather than sqlite.  Postgres has its own dialect.

We might want to worry about the order of checking with isinstance at some point.
