### PR TITLE
python: support By(t, t, t.reduction())

### DIFF
--- a/blaze/compute/python.py
+++ b/blaze/compute/python.py
@@ -65,6 +65,9 @@ def recursive_rowfunc(t):
     else:
         return compose(*funcs)
 
+@dispatch(TableSymbol)
+def rowfunc(t):
+    return identity
 
 @dispatch(Projection)
 def rowfunc(t):
@@ -242,10 +245,6 @@ binops = {sum: (operator.add, 0),
 @dispatch(By, Sequence)
 def compute(t, seq):
     parent = compute(t.parent, seq)
-
-    if not isinstance(t.grouper, Projection) and t.grouper.parent == t.parent:
-        raise NotImplementedError("Grouper attribute of By must be Projection "
-                                  "of parent table, got %s" % str(t.grouper))
 
     if (isinstance(t.apply, Reduction) and
         type(t.apply) in binops):

--- a/blaze/compute/tests/test_python.py
+++ b/blaze/compute/tests/test_python.py
@@ -72,6 +72,11 @@ def test_mean():
     assert 50 < compute(std(t['amount']), data) < 100
 
 
+def test_by_no_grouper():
+    names = t['name']
+    assert set(compute(By(names, names, names.count()), data)) == \
+            set([('Alice', 2), ('Bob', 1)])
+
 def test_by_one():
     print(compute(By(t, t['name'], t['amount'].sum()), data))
     assert set(compute(By(t, t['name'], t['amount'].sum()), data)) == \


### PR DESCRIPTION
Previously we expected the grouper to be a projection.  Now we allow it to be
any rowfuncable

cc @talumbau
