### PR TITLE
Skip gzip csv tests on windows py2.x

### DIFF
--- a/blaze/data/tests/test_integrative.py
+++ b/blaze/data/tests/test_integrative.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import sys
 import gzip
 from functools import partial
 from unittest import TestCase
@@ -7,9 +8,11 @@ from datashape import var, dshape
 
 from blaze.data import *
 from blaze.utils import filetexts
+from blaze.compatibility import skipIf
 import json
 
-import json
+
+is_py2_win = sys.platform == 'win32' and sys.version_info[:2] < (3, 0)
 
 data = {'a.json': {u'name': u'Alice', u'amount': 100},
         'b.json': {u'name': u'Bob', u'amount': 200},
@@ -24,6 +27,7 @@ texts = dict((fn, json.dumps(val)) for fn, val in data.items())
 schema = '{name: string, amount: int}'
 
 class Test_Integrative(TestCase):
+    @skipIf(is_py2_win, 'Win32 py2.7 unicode/gzip/eol needs sorting out')
     def test_gzip_json_files(self):
         with filetexts(texts, open=gzip.open) as filenames:
             descriptors = [JSON(fn, dshape=schema, open=gzip.open)

--- a/blaze/data/tests/test_open.py
+++ b/blaze/data/tests/test_open.py
@@ -1,12 +1,17 @@
 
+import sys
 from functools import partial
 from blaze.data import CSV, JSON
 
 from blaze.utils import tmpfile, raises
 from blaze.data.utils import tuplify
+from blaze.compatibility import skipIf
 
 import gzip
 
+is_py2_win = sys.platform == 'win32' and sys.version_info[:2] < (3, 0)
+
+@skipIf(is_py2_win, 'Win32 py2.7 unicode/gzip/eol needs sorting out')
 def test_gzopen_csv():
     with tmpfile('.csv.gz') as filename:
         f = gzip.open(filename, 'wt')
@@ -22,6 +27,7 @@ def test_gzopen_csv():
         assert tuplify(list(dd)) == ((1, 1), (2, 2))
 
 
+@skipIf(is_py2_win, 'Win32 py2.7 unicode/gzip/eol needs sorting out')
 def test_gzopen_json():
     with tmpfile('.json.gz') as filename:
         f = gzip.open(filename, 'wt')


### PR DESCRIPTION
We should revert this again after release.
