### PR TITLE
expr: Join automatically selects all shared columns

### DIFF
--- a/blaze/expr/table.py
+++ b/blaze/expr/table.py
@@ -418,6 +418,11 @@ class ColumnWise(RowWise, ColumnSyntaxMixin):
         return sorted(unique(x.name for x in self.traverse()
                                     if isinstance(x, ScalarSymbol)))
 
+def unpack(l):
+    if isinstance(l, (tuple, list, set)) and len(l) == 1:
+        return next(iter(l))
+    else:
+        return l
 
 class Join(TableExpr):
     """ Join two tables on common columns
@@ -443,9 +448,13 @@ class Join(TableExpr):
 
     iscolumn = False
 
-    def __init__(self, lhs, rhs, on_left, on_right=None):
+    def __init__(self, lhs, rhs, on_left=None, on_right=None):
         self.lhs = lhs
         self.rhs = rhs
+        if not on_left and not on_right:
+            on_left = on_right = unpack(list(sorted(
+                set(lhs.columns) & set(rhs.columns),
+                key=lhs.columns.index)))
         if not on_right:
             on_right = on_left
         if isinstance(on_left, tuple):

--- a/blaze/expr/tests/test_table.py
+++ b/blaze/expr/tests/test_table.py
@@ -108,6 +108,12 @@ def test_join():
     assert Join(t, s, 'name') == Join(t, s, 'name')
 
 
+def test_join_default_shared_columns():
+    t = TableSymbol('t', '{name: string, amount: int}')
+    s = TableSymbol('t', '{name: string, id: int}')
+    assert Join(t, s) == Join(t, s, 'name', 'name')
+
+
 def test_multi_column_join():
     a = TableSymbol('a', '{x: int, y: int, z: int}')
     b = TableSymbol('b', '{w: int, x: int, y: int}')


### PR DESCRIPTION
``` Python
t = TableSymbol('t', '{name: string, amount: int}')
s = TableSymbol('t', '{name: string, id: int}')
assert Join(t, s) == Join(t, s, 'name', 'name')
```
