### PR TITLE
Fix repr when Table is backed by mutable data

### DIFF
--- a/blaze/api/into.py
+++ b/blaze/api/into.py
@@ -7,6 +7,7 @@ from datashape.user import validate, issubschema
 from numbers import Number
 from collections import Iterable, Iterator
 import numpy as np
+from pandas import DataFrame, Series
 
 from ..dispatch import dispatch
 
@@ -60,7 +61,6 @@ def into(a, b):
     return b.tolist()
 
 from blaze.data import DataDescriptor
-from pandas import DataFrame
 @dispatch(DataFrame, DataDescriptor)
 def into(a, b):
     return DataFrame(list(b), columns=b.columns)
@@ -90,6 +90,10 @@ def into(df, seq):
 @dispatch(DataFrame, DataFrame)
 def into(_, df):
     return df.copy()
+
+@dispatch(DataFrame, Series)
+def into(_, df):
+    return DataFrame(df)
 
 @dispatch(nd.array, DataFrame)
 def into(a, df):

--- a/blaze/api/table.py
+++ b/blaze/api/table.py
@@ -64,11 +64,14 @@ class Table(TableSymbol):
     def resources(self):
         return {self: self.data}
 
-    def __hash__(self):
-        return hash((self.schema, self.name, id(self.data)))
+    @property
+    def args(self):
+        return (id(self.data), self.schema, self.name, self.iscolumn)
 
-    def traverse(self):
-        return [self]
+
+@dispatch(Table, dict)
+def _subs(o, d):
+    return o
 
 
 @dispatch(Table)

--- a/blaze/api/tests/test_into.py
+++ b/blaze/api/tests/test_into.py
@@ -115,6 +115,21 @@ def test_pandas_pandas():
     assert id(new_df) != id(df)
 
 
+@skip_if_not(DataFrame)
+def test_DataFrame_Series():
+    data = [('Alice', 100), ('Bob', 200)]
+    df = DataFrame(data, columns=['name', 'balance'])
+
+    new_df = into(DataFrame, df['name'])
+
+    assert np.all(new_df == DataFrame([['Alice'], ['Bob']], columns=['name']))
+
+    # new_df should be a copy of df
+    assert id(new_df) != id(df['name'])
+
+    assert isinstance(new_df, DataFrame)
+
+
 def test_discover_ndarray():
     data = [['Alice', 100], ['Bob', 200]]
     schema='{name: string, balance: int32}'

--- a/blaze/api/tests/test_table.py
+++ b/blaze/api/tests/test_table.py
@@ -74,3 +74,13 @@ def test_dataframe_backed_repr():
     dataframe_backed_table = Table(df)
     repr(dataframe_backed_table)
 
+
+def test_dataframe_backed_repr_complex():
+    df = pd.DataFrame([(1, 'Alice', 100),
+                       (2, 'Bob', -200),
+                       (3, 'Charlie', 300),
+                       (4, 'Denis', 400),
+                       (5, 'Edith', -500)],
+                      columns=['id', 'name', 'balance'])
+    t = Table(df)
+    repr(t[t['balance'] < 0])

--- a/blaze/expr/core.py
+++ b/blaze/expr/core.py
@@ -61,16 +61,48 @@ class Expr(object):
 
 
 def subs(o, d):
-    if o in d:
-        d = d.copy()
-        other = d.pop(o)
-        return subs(other, d)
-    if isinstance(o, (tuple, list)):
-        return type(o)([subs(arg, d) for arg in o])
-    if hasattr(o, 'args'):
-        newargs = [subs(arg, d) for arg in o.args]
-        return type(o)(*newargs)
+    """ Substitute values within data structure
 
+    >>> subs(1, {1: 2})
+    2
+
+    >>> subs([1, 2, 3], {2: 'Hello'})
+    [1, 'Hello', 3]
+    """
+    try:
+        if o in d:
+            d = d.copy()
+            o = d.pop(o)
+    except TypeError:
+        pass
+    return _subs(o, d)
+
+
+@dispatch((tuple, list), dict)
+def _subs(o, d):
+    return type(o)([subs(arg, d) for arg in o])
+
+
+@dispatch(Expr, dict)
+def _subs(o, d):
+    """
+
+    >>> from blaze.expr.table import TableSymbol
+    >>> t = TableSymbol('t', '{name: string, balance: int}')
+    >>> subs(t, {'balance': 'amount'}).columns
+    ['name', 'amount']
+    """
+    newargs = [subs(arg, d) for arg in o.args]
+    return type(o)(*newargs)
+
+
+@dispatch(object, dict)
+def _subs(o, d):
+    """ Private dispatched version of ``subs``
+
+    >>> subs('Hello', {})
+    'Hello'
+    """
     return o
 
 


### PR DESCRIPTION
The data backing a table was being hashed while computing head. This resulted in TypeErrors when viewing Tables backed by DataFrames. 

Fixing this required changes in three places:
1. The hash of a Table is now the hash of the schema, the name and the id of the backing data.
   - This change could lead to unexpected behavior when there are multiple tables backed by equal but not identical data.
2. Traversing a TableExpr now doesn't touch the data backing any of the tables
3. Added into(DataFrame, DataFrame)
