### PR TITLE
support for Map of Columnwise

### DIFF
--- a/blaze/compute/python.py
+++ b/blaze/compute/python.py
@@ -110,9 +110,8 @@ def rowfunc(t):
 
 @dispatch(Map)
 def rowfunc(t):
-    if t.parent.columns and len(t.parent.columns) == 1:
-        return t.func
-    elif isinstance(t.parent, ColumnWise) and len(t.parent.active_columns()) == 2:
+    if (isinstance(t.parent, ColumnWise) or
+        (t.parent.columns and len(t.parent.columns) == 1)):
         return t.func
     else:
         return partial(apply, t.func)

--- a/blaze/compute/tests/test_python.py
+++ b/blaze/compute/tests/test_python.py
@@ -319,3 +319,11 @@ def test_map_columnwise():
 
     assert list(compute(expr, data)) == [((row[1]*row[2]) / 10) for row in data]
 
+
+def test_map_columnwise_of_selection():
+    tsel = t[ t['name'] == 'Alice' ]
+    colwise = tsel['amount'] * tsel['id']
+
+    expr = colwise.map(lambda x: x / 10, schema="{mod: int64}", iscolumn=True)
+
+    assert list(compute(expr, data)) == [((row[1]*row[2]) / 10) for row in data[::2]]


### PR DESCRIPTION
Needed to support map of columnwise:

```
data = [(1.0, 2.0, 'USA'),
        (1.0, 3.1, 'RUSSIA'),
        (2.2, 4.0, 'USA'),
        (1.0, 2.8, 'RUSSIA')]


s = '{t1:float64, t2:float64, name: string}'
t = TableSymbol('test', s)

tfinal = (t['t2']-t['t1']).map(lambda x: int(x), schema="{diff: int32}", iscolumn=True )
```

@mrocklin, interested in your thoughts. Needs additional changes to be more general.
