### PR TITLE
SQL databases match nullability to datashape.Option

### DIFF
--- a/blaze/data/tests/test_sql.py
+++ b/blaze/data/tests/test_sql.py
@@ -119,7 +119,14 @@ def test_discovery():
                  sa.Column('timestamp', sa.DateTime, primary_key=True))
 
     assert discover(s) == \
-            dshape('var * {name: string, amount: int32, timestamp: datetime}')
+            dshape('var * {name: ?string, amount: ?int32, timestamp: datetime}')
+
+
+def test_discover_null_columns():
+    assert dshape(discover(sa.Column('name', sa.String, nullable=True))) == \
+            dshape('{name: ?string}')
+    assert dshape(discover(sa.Column('name', sa.String, nullable=False))) == \
+            dshape('{name: string}')
 
 
 def test_discovery_engine():
@@ -143,12 +150,13 @@ def test_extend_empty():
 
 
 def test_schema_detection():
-    dd = SQL('sqlite:///my.db',
+    engine = sa.create_engine('sqlite:///:memory:')
+    dd = SQL(engine,
              'accounts',
              schema='{name: string, amount: int32}')
 
     dd.extend([['Alice', 100], ['Bob', 200]])
 
-    dd2 = SQL('sqlite:///my.db', 'accounts')
+    dd2 = SQL(engine, 'accounts')
 
     assert dd.schema == dd2.schema


### PR DESCRIPTION
We now inspect database columns for the `NOT NULL` attribute and use
that to determine if the analagous datashape should have Options or not

We hook this into the datashape-sqlalchemy converters and use
the database reflection built into SQLAlchemy
