### PR TITLE
python: by maps call to compute onto child

### DIFF
--- a/blaze/compute/python.py
+++ b/blaze/compute/python.py
@@ -242,7 +242,7 @@ def compute_one(t, seq, **kwargs):
         d = reduceby(grouper, binop2, seq, initial)
     else:
         groups = groupby(grouper, seq)
-        d = dict((k, compute(t.apply, v)) for k, v in groups.items())
+        d = dict((k, compute(t.apply, {t.child: v})) for k, v in groups.items())
 
     if t.grouper.iscolumn:
         return d.items()

--- a/blaze/compute/tests/test_python_compute.py
+++ b/blaze/compute/tests/test_python_compute.py
@@ -389,3 +389,20 @@ def test_recursive_rowfunc_is_used():
     expected = [('Alice', 2*(101 + 53)),
                 ('Bob', 2*(202))]
     assert set(compute(expr, data)) == set(expected)
+
+
+def test_by_groupby_deep():
+    data = [(1, 2, 'Alice'),
+            (1, 3, 'Bob'),
+            (2, 4, 'Alice'),
+            (2, 4, '')]
+
+    schema = '{x: int, y: int, name: string}'
+    t = TableSymbol('t', schema)
+
+    t2 = t[t['name'] != '']
+    t3 = merge(t2.x, t2.name)
+    expr = by(t3, t3.name, t3.x.mean())
+    result = set(compute(expr, data))
+    assert result == set([('Alice', 1.5), ('Bob', 1.0)])
+


### PR DESCRIPTION
In Python's by implementation we called `compute` on each group

```
d = dict((k, compute(t.apply, group))
            for k, group in groups.items())
```

We actually should have been mapping the child of the by operation to the
group.

```
d = dict((k, compute(t.apply, {t.child, group}))
            for k, group in groups.items())
```

Otherwise it just maps the data `group` to the lowest leaf it can find.

This adapts a test by @talumbau in #420

Fixes #420
