### PR TITLE
Speed up import by turning off multipledispatch ordering

### DIFF
--- a/blaze/__init__.py
+++ b/blaze/__init__.py
@@ -4,6 +4,11 @@ import logging
 
 from dynd import nd
 from pandas import DataFrame
+
+from multipledispatch import halt_ordering, restart_ordering
+
+halt_ordering() # Turn off multipledispatch ordering
+
 from .expr.table import *
 from .api import *
 from .data.csv import *
@@ -23,6 +28,7 @@ try:
 except ImportError:
     pass
 
+restart_ordering() # Restart multipledispatch ordering and do ordering
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
See https://github.com/mrocklin/multipledispatch/pull/29

This significantly speeds up import time.  Dispatch import time used to
dominate (4s if using all backends) now it's a small fraction of a second.
