### PR TITLE
expr: boolean fixes

### DIFF
--- a/blaze/expr/scalar/boolean.py
+++ b/blaze/expr/scalar/boolean.py
@@ -13,6 +13,9 @@ class BooleanInterface(Scalar):
     def __or__(self, other):
         return Or(self, other)
 
+    def __invert__(self):
+        return Not(self)
+
 
 class Boolean(BooleanInterface):
     @property
@@ -66,7 +69,7 @@ class Or(BinOp, Boolean):
 
 class Not(UnaryOp, Boolean):
     symbol = '~'
-    op = operator.not_
+    op = operator.invert
 
 
 Invert = Not

--- a/blaze/expr/scalar/numbers.py
+++ b/blaze/expr/scalar/numbers.py
@@ -10,7 +10,8 @@ from ..core import Expr
 from ...dispatch import dispatch
 from ...compatibility import _strtypes
 from datashape import coretypes as ct
-from .boolean import Eq, Ne, Lt, Gt, Le, Ge, And, Or, BitAnd, BitOr, Not, Invert
+from .boolean import (Eq, Ne, Lt, Gt, Le, Ge, And, Or, BitAnd, BitOr, Not,
+        Invert, BooleanInterface)
 
 
 @dispatch(ct.Option, object)
@@ -239,7 +240,7 @@ class floor(IntegerMath): pass
 class trunc(IntegerMath): pass
 
 
-class BooleanMath(Number, UnaryOp):
+class BooleanMath(Number, UnaryOp, BooleanInterface):
     """ Mathematical unary operator with bool valued dshape like isnan """
     @property
     def dshape(self):

--- a/blaze/expr/scalar/tests/test_scalar.py
+++ b/blaze/expr/scalar/tests/test_scalar.py
@@ -27,12 +27,25 @@ def test_eval_str():
 
     print(eval_str(-x))
     assert eval_str(-x) == '-x'
+    assert '~' in eval_str(~x)
 
 
 def test_str():
     x = ScalarSymbol('x', 'real')
-
     assert str(x + 10) == 'x + 10'
+
+
+def test_invert():
+    x = ScalarSymbol('x', 'bool')
+    expr = ~x
+    assert expr.op(x).isidentical(expr)
+
+
+def test_boolean_math_has_boolean_methods():
+    x = ScalarSymbol('x', '?int')
+    expr = ~(isnan(x)) | (x > 0)
+
+    assert eval(str(expr)).isidentical(expr)
 
 
 def ishashable(x):
@@ -49,7 +62,7 @@ def test_ScalarSymbol_is_hashable():
 
 def test_relationals():
     x = ScalarSymbol('x', 'real')
-    for expr in [x < 1, x > 1, x == 1, x != 1, x <= 1, x >= 1]:
+    for expr in [x < 1, x > 1, x == 1, x != 1, x <= 1, x >= 1, ~x]:
         assert expr.dshape == dshape('bool')
         assert eval(str(expr)) == expr
 

--- a/blaze/expr/table.py
+++ b/blaze/expr/table.py
@@ -14,7 +14,7 @@ from . import scalar
 from .core import Expr, path
 from .scalar import ScalarSymbol
 from .scalar import (Eq, Ne, Lt, Le, Gt, Ge, Add, Mult, Div, Sub, Pow, Mod, Or,
-                     And, USub, eval_str, Scalar)
+                     And, USub, Not, eval_str, Scalar, FloorDiv)
 from ..compatibility import _strtypes, builtins
 
 
@@ -307,6 +307,9 @@ class ColumnSyntaxMixin(object):
     def __neg__(self):
         return columnwise(USub, self)
 
+    def __invert__(self):
+        return columnwise(Not, self)
+
     def label(self, label):
         return Label(self, label)
 
@@ -327,6 +330,9 @@ class ColumnSyntaxMixin(object):
 
     def std(self):
         return std(self)
+
+    def isnan(self):
+        return columnwise(scalar.isnan, self)
 
 
 class Column(ColumnSyntaxMixin, Projection):
@@ -1137,6 +1143,12 @@ class Union(TableExpr):
     """
     __slots__ = 'children',
     __inputs__ = 'children',
+
+    def subterms(self):
+        yield self
+        for i in self.children:
+            for node in i.subterms():
+                yield node
 
     @property
     def schema(self):

--- a/blaze/expr/tests/test_table.py
+++ b/blaze/expr/tests/test_table.py
@@ -236,6 +236,8 @@ def test_unary_ops():
     expr = cos(exp(t['amount']))
     assert 'cos' in str(expr)
 
+    assert '~' in str(~(t.amount > 0))
+
 
 def test_reduction():
     t = TableSymbol('t', '{name: string, amount: int32}')
@@ -509,3 +511,13 @@ def test_table_coercion():
     assert (t.amount + '10').expr.rhs == 10
 
     assert (t.timestamp < '2014-12-01').expr.rhs == date(2014, 12, 1)
+
+
+def test_isnan():
+    t = TableSymbol('t', '{name: string, amount: int, timestamp: ?date}')
+
+    for expr in [t.amount.isnan(), ~t.amount.isnan()]:
+        assert eval(str(expr)).isidentical(expr)
+
+    assert isinstance(t.amount.isnan(), TableExpr)
+    assert 'bool' in str(t.amount.isnan().dshape)


### PR DESCRIPTION
Scalar boolean interface

isnan attribute on tables

Not uses operator.invert, not operator.not
