### PR TITLE
[WIP] csv_into (don't merge)

### DIFF
--- a/blaze/api/__init__.py
+++ b/blaze/api/__init__.py
@@ -1,2 +1,3 @@
 from .into import *
+from .csv_into import *
 from .table import *

--- a/blaze/api/csv_into.py
+++ b/blaze/api/csv_into.py
@@ -1,0 +1,69 @@
+from __future__ import absolute_import, division, print_function
+
+from dynd import nd
+import datashape
+from datashape import DataShape, dshape, Record, to_numpy_dtype
+import toolz
+from toolz import concat, partition_all, valmap
+from cytoolz import pluck
+import copy
+from datetime import datetime
+from datashape.user import validate, issubschema
+from numbers import Number
+from collections import Iterable, Iterator
+import numpy as np
+import pandas as pd
+from pandas import DataFrame, Series
+import h5py
+import tables
+
+from ..dispatch import dispatch
+from ..expr.table import TableExpr
+from ..compute.core import compute
+
+
+__all__ = ['csv_into']
+
+
+def csv_into(a, b, permit_errors=False, **kwargs):
+
+    if (permit_errors):
+        import sys
+        from io import StringIO
+        old_stderr = sys.stderr
+        sys.stderr = cap_stderr = StringIO()
+        ans = _csv_into(a, b, **kwargs)
+        sys.stderr = cap_stderr
+        cap_stderr.seek(0)
+        return ans, cap_stderr.read()
+    else:
+        return _csv_into(a, b, **kwargs)
+
+
+@dispatch(object, object)
+def _csv_into(a, b, **kwargs):
+    """
+    Push CSV-like data at pth into a container of type ``a``
+
+    """
+    raise NotImplementedError(
+        "Blaze does not know a rule for the following conversion"
+        "\n%s <- %s" % (type(a).__name__, type(b).__name__))
+
+
+@dispatch(DataFrame, str)
+def _csv_into(a, b, **kwargs):
+
+    import os
+    if os.path.isfile(b):
+        return pd.read_csv(b, header=None, error_bad_lines=False,
+                           warn_bad_lines=True)
+    elif os.path.isdir(b):
+        allFiles = glob.glob(os.path.join(b, "/*.csv"))
+        frame = pd.DataFrame()
+        alldfs = []
+        for f in allFiles:
+            df = pd.read_csv(f, header=None, error_bad_lines=False,
+                             warn_bad_lines=True)
+            alldfs.append(df)
+        return pd.concat(alldfs)

--- a/blaze/api/tests/test_csv_into.py
+++ b/blaze/api/tests/test_csv_into.py
@@ -1,0 +1,70 @@
+import unittest
+
+from dynd import nd
+import numpy as np
+import pandas as pd
+from datashape import dshape
+from datetime import datetime
+import tempfile
+import os
+
+from blaze.api.csv_into import csv_into
+import blaze
+from blaze import Table
+import pytest
+
+
+def skip(test_foo):
+    return
+
+
+def skip_if_not(x):
+    def maybe_a_test_function(test_foo):
+        if not x:
+            return
+        else:
+            return test_foo
+    return maybe_a_test_function
+
+try:
+    from pandas import DataFrame
+except ImportError:
+    DataFrame = None
+
+try:
+    from blaze.data import CSV
+except ImportError:
+    CSV = None
+
+try:
+    from bokeh.objects import ColumnDataSource
+except ImportError:
+    ColumnDataSource = None
+
+
+@pytest.yield_fixture
+def bad_csv():
+
+    with tempfile.NamedTemporaryFile(mode='w') as f:
+        badfile = open(f.name, mode="w")
+        # Insert a new record
+        badfile.write("a,b,c,d\n")
+        badfile.write("e,f,g,h\n")
+        badfile.write("i,j,k,l,m\n")
+        badfile.flush()
+        yield badfile
+        # Close (and flush) the file
+        badfile.close()
+
+
+@skip_if_not(CSV and DataFrame)
+def test_csv_into_dataframe(bad_csv):
+    df = csv_into(pd.DataFrame(), bad_csv.name)
+    assert len(df) == 2
+
+
+@skip_if_not(CSV and DataFrame)
+def test_csv_into_dataframe_errors(bad_csv):
+    df, err = csv_into(pd.DataFrame(), bad_csv.name, permit_errors=True)
+    assert len(df) == 2
+    assert err


### PR DESCRIPTION
I like the `into` interface so much that I thought of this as a way to get stuff from disk:

```
df = csv_into(pd.DataFrame(), "data.csv")
bigdf = csv_into(pd.DataFrame(), "/path/to/csvs")
```

Error handling works like this:

```
df, errs = csv_into(pd.DataFrame(), "data.csv", permit_errors=True)
```

Errors are dropped and reported in `errs`
Right now this just leverages `pandas.read_csv`

TODO
- [ ] handle schemas via a `datashape` argument
- [ ] maybe support `sql_into`
- [ ] support URIs in the path argument
