### PR TITLE
Fixes MySQL TravisCI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ addons:
 services:
     - mongodb
     - postgres
+    - mysql
+
 
 # Note: conda is not available for anything but python 2.7. So below we try to install
 # conda in 2.7 and use conda to install dependencies in the virtualenv for version x.y
@@ -78,6 +80,9 @@ install:
 
   # Install Blaze
   - python setup.py install
+
+before_script:
+  - mysql -e 'create database test'
 
 script: py.test --doctest-modules --verbose --pyargs blaze
 

--- a/blaze/data/dialect_mappings.py
+++ b/blaze/data/dialect_mappings.py
@@ -27,4 +27,6 @@ dialect_terms = {'delimiter': "delimiter", # Delimiter character (ALL)
                  'HEADER': "header",
                  'encoding': "encoding", # Charatcter Encoding -- POSTGRES: utf (default),MySQL latin1 (default)
                  'ENCODING': "encoding",
+                 'local': "local", # MySQL LOAD DATA ARG. -- used when file is located on client host
+                 "LOCAL": "local", # http://dev.mysql.com/doc/refman/5.1/en/load-data-local.html
                  }

--- a/blaze/data/sql.py
+++ b/blaze/data/sql.py
@@ -340,11 +340,12 @@ def into(sql, csv, if_exists="replace", **kwargs):
     quotechar = retrieve_kwarg('quotechar') or '"'
     escapechar = retrieve_kwarg('escapechar') or quotechar
     header = retrieve_kwarg('header') or csv.header
-    lineterminator = retrieve_kwarg('lineterminator') or u'\n'
+    lineterminator = retrieve_kwarg('lineterminator') or u'\r\n'
 
     skiprows = csv.header or 0 # None or 0 returns 0
     skiprows = retrieve_kwarg('skiprows') or int(skiprows) #hack to skip 0 or 1
 
+    mysql_local = retrieve_kwarg('local') or ''
 
     copy_info = {'abspath': abspath,
                  'tblname': tblname,
@@ -357,7 +358,8 @@ def into(sql, csv, if_exists="replace", **kwargs):
                  'lineterminator': lineterminator,
                  'skiprows': skiprows,
                  'header': header,
-                 'encoding': encoding}
+                 'encoding': encoding,
+                 'mysql_local': mysql_local}
 
     if if_exists == 'replace':
         if engine.has_table(tblname):
@@ -424,7 +426,7 @@ def into(sql, csv, if_exists="replace", **kwargs):
 
             #no null handling
             sql_stmnt = u"""
-                        LOAD DATA LOCAL INFILE '{abspath}'
+                        LOAD DATA {mysql_local} INFILE '{abspath}'
                         INTO TABLE {tblname}
                         CHARACTER SET {encoding}
                         FIELDS
@@ -435,7 +437,6 @@ def into(sql, csv, if_exists="replace", **kwargs):
                         IGNORE {skiprows} LINES;
                         """
             sql_stmnt = sql_stmnt.format(**copy_info)
-
             cursor.execute(sql_stmnt)
             conn.commit()
 


### PR DESCRIPTION
This PR fixes the MySQL TravisCI testing as well as a more comprehensive MySQL cmd.  The issue stems from the `LOCAL` argument previously supplied.  As described [here],(http://dev.mysql.com/doc/refman/5.1/en/load-data-local.html) `LOCAL` indicates that the server should pull the file from the client and this is a potential security issue.  Both the client and the server have to support the use of `LOCAL` -- TravisCI has this disabled on the client side by default.

The client must be set with: mysql --local-infile=1 or set in /etc/mysql/my.cnf

And the server:
mysql>SHOW GLOBAL VARIABLES LIKE 'local_infile'

+---------------+-------+
| Variable_name | Value |
+---------------+-------+
| local_infile | ON |
+---------------+-------+

The sql cmd now has an optional argument `mysql_local` which by default is empty and should only be set to `LOCAL`

More info here: http://bugs.mysql.com/bug.php?id=72220
