### PR TITLE
set default server port to 6363

### DIFF
--- a/blaze/server/server.py
+++ b/blaze/server/server.py
@@ -18,6 +18,10 @@ from datashape import Mono
 
 from .index import parse_index
 
+# http://www.speedguide.net/port.php?port=6363
+# http://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers
+DEFAULT_PORT = 6363
+
 class Server(object):
     """ Blaze Data Server
 
@@ -32,7 +36,7 @@ class Server(object):
     ...                columns=['id', 'name', 'amount'])
 
     >>> server = Server({'accounts': df})
-    >>> server.app.run() # doctest: +SKIP
+    >>> server.run() # doctest: +SKIP
     """
     __slots__ = 'app', 'datasets'
 
@@ -50,6 +54,10 @@ class Server(object):
     def __setitem__(self, key, value):
         self.datasets[key] = value
         return value
+
+    def run(self, *args, **kwargs):
+        port = kwargs.pop('port', DEFAULT_PORT)
+        return self.app.run(*args, port=port, **kwargs)
 
 
 routes = list()

--- a/blaze/server/tests/test_client.py
+++ b/blaze/server/tests/test_client.py
@@ -28,7 +28,7 @@ import blaze.server.client as client
 client.requests = test # OMG monkey patching
 
 
-dd = Client('http://localhost:5000', 'accounts')
+dd = Client('http://localhost:6363', 'accounts')
 
 def test_dshape():
     assert dd.dshape == accounts.dshape
@@ -54,7 +54,7 @@ def test_chunks():
 
 
 def test_expr_client():
-    ec = ExprClient('localhost:5000', 'accounts_df')
+    ec = ExprClient('localhost:6363', 'accounts_df')
     assert discover(ec) == discover(df)
 
     t = TableSymbol('t', discover(ec))
@@ -65,7 +65,7 @@ def test_expr_client():
 
 
 def test_expr_client_interactive():
-    ec = ExprClient('localhost:5000', 'accounts_df')
+    ec = ExprClient('localhost:6363', 'accounts_df')
     t = Table(ec)
 
     assert compute(t.name) == ['Alice', 'Bob']
@@ -75,9 +75,13 @@ def test_expr_client_interactive():
 
 
 def test_resource():
-    ec = resource('blaze://localhost:5000', 'accounts_df')
+    ec = resource('blaze://localhost:6363', 'accounts_df')
+    assert discover(ec) == discover(df)
+
+def test_resource_default_port():
+    ec = resource('blaze://localhost', 'accounts_df')
     assert discover(ec) == discover(df)
 
 def test_resource_all_in_one():
-    ec = resource('blaze://localhost:5000::accounts_df')
+    ec = resource('blaze://localhost:6363::accounts_df')
     assert discover(ec) == discover(df)

--- a/docs/source/server.rst
+++ b/docs/source/server.rst
@@ -35,14 +35,14 @@ To demonstrate the use of the Blaze server we serve the iris csv file.
 
 
 Then we host this under the name ``'iris'`` and serve publicly on port
-``5000``
+``6363``
 
 
 .. code-block:: python
 
    >>> from blaze.server import Server
    >>> server = Server({'iris': csv})
-   >>> server.app.run(host='0.0.0.0', port=5000)
+   >>> server.run(host='0.0.0.0', port=6363)
 
 A Server is the following
 
@@ -50,14 +50,14 @@ A Server is the following
 2.  A `Flask <http://flask.pocoo.org/docs/0.10/quickstart/#a-minimal-application>`_ app.
 
 With this code our machine is now hosting our CSV file through a
-web-application on port 5000.  We can now access our CSV file, through Blaze,
+web-application on port 6363.  We can now access our CSV file, through Blaze,
 as a service from a variety of applications.
 
 Interacting with the Web Server from the Client
 ===============================================
 
 Computation is now available on this server at
-``hostname:5000/compute/iris.json``.  To communicate the computation to be done
+``hostname:6363/compute/iris.json``.  To communicate the computation to be done
 we pass Blaze expressions in JSON format through the request.  See the examples
 below.
 
@@ -69,7 +69,7 @@ We can use standard command line tools to interact with this web service::
    $ curl \
        -H "Content-Type: application/json" \
        -d '{"expr": {"op": "Column", "args": ["iris", "species"]}}' \
-       localhost:5000/compute/iris.json
+       localhost:6363/compute/iris.json
 
    {
      "data": [
@@ -86,7 +86,7 @@ We can use standard command line tools to interact with this web service::
        -d  '{"expr": {"op": "sum", \
                       "args": [{"op": "Column", \
                                  "args": ["iris", "petal_Length"]}]}}' \
-       localhost:5000/compute/iris.json
+       localhost:6363/compute/iris.json
 
    {
      "data": 563.8000000000004,
@@ -116,7 +116,7 @@ First we repeat the same experiment as before, this time using the Python
    ...                   'args': [{'op': 'Column',
    ...                             'args': ['iris', 'petal_length']}]}}
 
-   >>> r = requests.get('http://localhost:5000/compute/iris.json',
+   >>> r = requests.get('http://localhost:6363/compute/iris.json',
    ...                 data=json.dumps(query),
    ...                 headers={'Content-Type': 'application/json'})
 
@@ -164,7 +164,7 @@ do work for us
 
    >>> from blaze import *
    >>> from blaze.server import ExprClient
-   >>> ec = ExprClient('http://localhost:5000', 'iris')
+   >>> ec = ExprClient('http://localhost:6363', 'iris')
 
    >>> t = Table(ec)
        sepal_length  sepal_width  petal_length  petal_width      species


### PR DESCRIPTION
This sets the default server port to `6363`.  The protocol `blaze://` now uses this port by default as well

``` Python
>>> server.run()  # port=6363 by default

>>> Table('blaze://localhost:6363')  # Before
>>> Table('blaze://localhost')       # After
```

ping @aterrel 
