### PR TITLE
 Removed duplicate into() definitions

### DIFF
--- a/blaze/api/into.py
+++ b/blaze/api/into.py
@@ -704,21 +704,16 @@ def into(_, dd, **kwargs):
     return iter(dd)
 
 
-@dispatch((np.ndarray, pd.DataFrame, ColumnDataSource, ctable), DataDescriptor)
+@dispatch((np.ndarray, ColumnDataSource, ctable), DataDescriptor)
 def into(a, b, **kwargs):
     return into(a, into(nd.array(), b), **kwargs)
 
 
-@dispatch((np.ndarray, pd.DataFrame, ColumnDataSource, ctable, tables.Table,
+@dispatch((np.ndarray, ColumnDataSource, ctable, tables.Table,
     list, tuple, set),
           CSV)
 def into(a, b, **kwargs):
     return into(a, into(pd.DataFrame(), b, **kwargs), **kwargs)
-
-
-@dispatch(np.ndarray, CSV)
-def into(a, b, **kwargs):
-    return into(a, into(pd.DataFrame(), b, **kwargs))
 
 
 @dispatch(pd.DataFrame, CSV)


### PR DESCRIPTION
Removed duplicate into(pd.DataFrame, CSV) so that the currently used (and better) version is the only one defined.

Removed duplicate into(pd.DataFrame, DataDescriptor) so that the currently used version is the only one defined.
Note: I'm not certain that the current into(pd.DataFrame, DataDescriptor) is better than the version that was removed.
The unused version allows an existing dataframe to be populated with select columns from the source.
The currently used version makes a new dataframe and populates it with all data.
