### PR TITLE
xfail on sqlite3 command not available on windows

### DIFF
--- a/blaze/tests/test_sqlite_into.py
+++ b/blaze/tests/test_sqlite_into.py
@@ -18,7 +18,7 @@ file_name = 'test.csv'
 def setup_function(function):
     data = [(1, 2), (10, 20), (100, 200)]
 
-    kwargs = {'newline': ''} if PY3 else {}
+    kwargs = {'newline': ''} if PY3 and os.name == 'nt' else {}
 
     with open(file_name, 'w', **kwargs) as f:
         csv_writer = csv_module.writer(f)


### PR DESCRIPTION
Round one of possibly more fixes

Tested these on a Windows 7 64-bit with Python 3.4
