### PR TITLE
Add frequencies attribute to tableexprs

### DIFF
--- a/blaze/expr/table.py
+++ b/blaze/expr/table.py
@@ -188,7 +188,7 @@ class TableExpr(Expr):
     def __ge__(self, other):
         return columnwise(Ge, self, other)
 
-    def frequencies(self):
+    def count_values(self):
         """ Count occurrences of elements in this column """
         assert self.iscolumn
         return by(self, count=self.count())

--- a/blaze/expr/tests/test_table.py
+++ b/blaze/expr/tests/test_table.py
@@ -808,6 +808,6 @@ def test_like():
     assert expr.dshape[0] == datashape.var
 
 
-def test_frequencies():
+def test_count_values():
     t = TableSymbol('t', '{name: string, amount: int, city: string}')
-    assert t.name.frequencies().isidentical(by(t.name, count=t.name.count()))
+    assert t.name.count_values().isidentical(by(t.name, count=t.name.count()))


### PR DESCRIPTION
This shortcuts to `by(self, count=self.count())`  I find myself doing this often enough that it might be useful.

Thoughts on the name?  Is there a better API?  Pandas.Series uses value_counts.  Toolz uses frequencies.  `counts` might work but it conflicts with `count`.
