### PR TITLE
mongo post_compute robust to missing keys

### DIFF
--- a/blaze/compute/mongo.py
+++ b/blaze/compute/mongo.py
@@ -260,9 +260,9 @@ def post_compute(e, q, d):
     dicts = q.coll.aggregate(list(q.query))['result']
 
     if e.iscolumn:
-        return list(pluck(e.columns[0], dicts)) # dicts -> values
+        return list(pluck(e.columns[0], dicts, default=None)) # dicts -> values
     else:
-        return list(pluck(e.columns, dicts))    # dicts -> tuples
+        return list(pluck(e.columns, dicts, default=None))    # dicts -> tuples
 
 
 def name(e):


### PR DESCRIPTION
```
Use pluck(default=None)
```
