### PR TITLE
Accept dot-delimited schemaname.tablename 

### DIFF
--- a/blaze/data/sql.py
+++ b/blaze/data/sql.py
@@ -185,7 +185,7 @@ class SQL(DataDescriptor):
         if isinstance(engine, _strtypes):
             engine = sql.create_engine(engine)
         self.engine = engine
-        self.schemaname = '.'.join(tablename.split('.')[:-1]) or None
+        self.schemaname = tablename.rsplit('.', 1)[0] if ('.' in tablename) else None
         self.tablename = tablename.split('.')[-1]
         self.dbtype = engine.url.drivername
         metadata = sql.MetaData()


### PR DESCRIPTION
Presently, blaze.SQL isn't accepting <schemaname>.<tablename> to identify tables outside the connecting user's own schema.  Parsing out a dot-delimited prefix and passing it to SQLAlchemy as "schema" fixes that.

I apologize for not including tests, but I haven't been able to get the tests to run.  Hopefully the small size of the pull request makes that OK.
