### PR TITLE
chunk compute by uses split

### DIFF
--- a/blaze/compute/tests/test_chunks_compute.py
+++ b/blaze/compute/tests/test_chunks_compute.py
@@ -91,13 +91,13 @@ def test_join():
 
 
 def test_by():
-    assert set(compute(by(t.name, t.amount.sum()), c)) == \
+    assert set(compute(by(t.name, sum=t.amount.sum()), c)) == \
             set([('Alice', -200), ('Bob', 200),
                  ('Charlie', 400), ('Edith', 200)])
-    assert set(compute(by(t.name, t.amount.count()), c)) == \
+
+    assert set(compute(by(t.name, count=t.amount.count()), c)) == \
             set([('Alice', 2), ('Bob', 1),
                  ('Charlie', 1), ('Edith', 1)])
-
 
 def test_into_list_chunks():
     assert into([], ChunkIterable([1, 2, 3, 4], chunksize=2)) == [1, 2, 3, 4]

--- a/blaze/expr/tests/test_split.py
+++ b/blaze/expr/tests/test_split.py
@@ -63,7 +63,7 @@ def test_summary():
     assert agg_expr.isidentical(summary(total=agg.total.sum()))
 
 
-def test_by():
+def test_by_sum():
     (chunk, chunk_expr), (agg, agg_expr) = \
             split(t, by(t.name, total=t.amount.sum()))
 
@@ -71,6 +71,14 @@ def test_by():
     assert chunk_expr.isidentical(by(chunk.name, total=chunk.amount.sum()))
 
     assert not agg.iscolumn
+    assert agg_expr.isidentical(by(agg.name, total=agg.total.sum()))
+
+def test_by_count():
+    (chunk, chunk_expr), (agg, agg_expr) = \
+            split(t, by(t.name, total=t.amount.count()))
+
+    assert chunk_expr.isidentical(by(chunk.name, total=chunk.amount.count()))
+
     assert agg_expr.isidentical(by(agg.name, total=agg.total.sum()))
 
 


### PR DESCRIPTION
There was an error in `compute_up(By, ChunkIterator)`  I took this as an opportunity to stretch expr.split, which is designed to make these things easy.
