### PR TITLE
Server namespaces

### DIFF
--- a/blaze/server/server.py
+++ b/blaze/server/server.py
@@ -255,8 +255,10 @@ def comp(datasets, name):
         return ("Dataset %s not found" % name, 404)
 
     t = Symbol(name, discover(dset))
+    namespace = data.get('namespace', dict())
+    namespace[name] = t
 
-    expr = from_tree(data['expr'], namespace={name: t})
+    expr = from_tree(data['expr'], namespace=namespace)
 
     result = compute(expr, dset)
     if iscollection(expr.dshape):


### PR DESCRIPTION
Traditionally the computation route on the server accepts and executes a Blaze computation on the stored data source. 

```
request = {'expr': some-json-representation-of-blaze-expression}
```

We add the option to provide a namespace to the request.  Blaze will substitute values accordingly.  This is useful for parametrized expressions where the parameters are stored separately.

```
request = {'expr': some-json-representation-of-blaze-expression,
           'namespace': {'parameter': value}}
```
