### PR TITLE
Handle joins on the same table by using sqlalchemy alias

### DIFF
--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -21,6 +21,7 @@ import sqlalchemy
 from sqlalchemy import sql
 from sqlalchemy.sql import Selectable, Select
 from sqlalchemy.sql.elements import ClauseElement, ColumnElement
+from sqlalchemy.sql.selectable import alias
 from operator import and_
 from datashape import Record
 from copy import copy


### PR DESCRIPTION
Very basic change. It did work for my needs.

I could get the following code to work:

r = bl.by(tbl_inventory_detail['isbn'],id=bl.max(tbl_inventory_detail['id']))
r = bl.join(r['id'],tbl_inventory_detail,'id','id')
