### PR TITLE
Into clientdataset

### DIFF
--- a/blaze/server/client.py
+++ b/blaze/server/client.py
@@ -5,6 +5,7 @@ from flask import json
 import flask
 from dynd import nd
 from datashape import dshape, DataShape, Record
+from pandas import DataFrame
 
 from ..data import DataDescriptor
 from ..data.utils import coerce
@@ -129,7 +130,6 @@ def compute_down(expr, ec, **kwargs):
     from .server import to_tree
     from ..api import Data
     from ..api import into
-    from pandas import DataFrame
     leaf = expr._leaves()[0]
     tree = to_tree(expr, dict((leaf[f], f) for f in leaf.fields))
 
@@ -152,6 +152,10 @@ def into(_, c, **kwargs):
                      headers={'Content-Type': 'application/json'})
     data = json.loads(content(r))
     return data['data']
+
+@dispatch(DataFrame, ClientDataset)
+def into(_, c, **kwargs):
+    return into(DataFrame, into(list, c), columns=c.dshape.measure.names)
 
 
 @resource.register('blaze://.+::.+', priority=16)

--- a/blaze/server/tests/test_client.py
+++ b/blaze/server/tests/test_client.py
@@ -55,6 +55,13 @@ def test_clientdataset_into_list():
     assert into(list, a) == [['Alice', 100], ['Bob', 200]]
 
 
+def test_clientdataset_into_list():
+    a = resource('blaze://localhost:6363::accounts')
+
+    assert str(into(DataFrame, a)) == \
+            str(DataFrame([['Alice', 100], ['Bob', 200]],
+                          columns=['name', 'amount']))
+
 def test_resource():
     c = resource('blaze://localhost:6363')
     assert str(discover(c)) == str(discover({'accounts': df}))


### PR DESCRIPTION
Just a couple of routes.  Note that most other things can be done by composing these, e.g. 

```
into(np.ndarray, into(DataFrame, 'blaze://localhost::accounts'))
```

I plan to automate something like the composition above in moderate future so I'm hesitant to do it piecemeal here.

Does this handle current requirements @hhuuggoo ?  I can also put in any particular solution.  Just not planning on handling them all.
