### PR TITLE
Add mapping for NUMERIC sqlalchemy type

### DIFF
--- a/blaze/data/sql.py
+++ b/blaze/data/sql.py
@@ -53,6 +53,7 @@ revtypes.update({sql.types.VARCHAR: 'string',
                  sql.types.DATE: 'date',
                  sql.types.BIGINT: 'int64',
                  sql.types.INTEGER: 'int',
+                 sql.types.NUMERIC: 'int',  # TODO: extend datashape to decimal
                  sql.types.BIGINT: 'int64',
                  sql.types.Float: 'float64'})
 

--- a/blaze/data/tests/test_sql.py
+++ b/blaze/data/tests/test_sql.py
@@ -127,6 +127,14 @@ def test_discovery():
     assert discover(s) == \
             dshape('var * {name: ?string, amount: ?int32, timestamp: datetime}')
 
+def test_discovery_numeric_column():
+    assert discover(sa.String()) == datashape.string
+    metadata = sa.MetaData()
+    s = sa.Table('name', metadata,
+                 sa.Column('name', sa.types.NUMERIC),)
+
+    assert discover(s)
+
 
 def test_discover_null_columns():
     assert dshape(discover(sa.Column('name', sa.String, nullable=True))) == \


### PR DESCRIPTION
Currently this just maps to integer.  Do we want to extend datashape to decimals? (see https://github.com/ContinuumIO/datashape/issues/118).
