### PR TITLE
skip postgres tests if credentials don't work

### DIFF
--- a/blaze/tests/test_postgres_into.py
+++ b/blaze/tests/test_postgres_into.py
@@ -24,6 +24,21 @@ import numpy as np
 url = 'postgresql://localhost/postgres'
 file_name = 'test.csv'
 
+
+try:
+    url = 'postgresql://localhost/postgres'
+    engine = sqlalchemy.create_engine(url)
+    name = 'tmpschema'
+    create = sqlalchemy.schema.CreateSchema(name)
+    engine.execute(create)
+    metadata = sqlalchemy.MetaData()
+    metadata.reflect(engine, schema=name)
+    drop = sqlalchemy.schema.DropSchema(name)
+    engine.execute(drop)
+except sqlalchemy.exc.OperationalError:
+    pytestmark = pytest.mark.skipif(True, reason="Can not connect to postgres")
+
+
 def setup_function(function):
     data = [(1, 2), (10, 20), (100, 200)]
 


### PR DESCRIPTION
These credentials work on travis.ci.  They don't necessarily work on a user's local installation.  This adds another test skip criterion.  @quasiben 
