### PR TITLE
expr: binop propagates names when they're the same

### DIFF
--- a/blaze/expr/arithmetic.py
+++ b/blaze/expr/arithmetic.py
@@ -46,6 +46,8 @@ class BinOp(ElemWise):
             return l
         if r and not l:
             return r
+        if l == r:
+            return l
 
     @property
     def _inputs(self):

--- a/blaze/expr/tests/test_arithmetic.py
+++ b/blaze/expr/tests/test_arithmetic.py
@@ -32,6 +32,8 @@ def test_names():
     assert Add(y, x)._name != x._name
     assert Add(y, x)._name != y._name
 
+    assert Add(x, x)._name == x._name
+
 def test_inputs():
     assert (x + y)._inputs == (x, y)
     assert (x + 1)._inputs == (x,)


### PR DESCRIPTION
Fixes #871
