### PR TITLE
sql: count is robust to failing primary key

### DIFF
--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -312,8 +312,17 @@ def compute_up(t, s, **kwargs):
 
 @dispatch(count, Select)
 def compute_up(t, s, **kwargs):
-    s2 = s.alias(next(aliases)).count()
-    return select([list(inner_columns(s2))[0].label(t._name)])
+    al = next(aliases)
+    try:
+        s2 = s.alias(al)
+        col = list(s2.primary_key)[0]
+    except (KeyError, IndexError):
+        s2 = s.alias(al)
+        col = list(s2.columns)[0]
+
+    result = sqlalchemy.sql.functions.count(col)
+
+    return select([list(inner_columns(result))[0].label(t._name)])
 
 
 @dispatch(nunique, sqlalchemy.Column)


### PR DESCRIPTION
If The SQLAlchemy .primary_key attribute is missing its
.columns attribute starts returning [].  This stateful change causes
problems in try-except code blocks as occurs in count on selections.

This change works around this issue in Blaze.  We should probably
report up to SQLAlchemy as well.
