### PR TITLE
Make resource case insensitive

### DIFF
--- a/blaze/regex.py
+++ b/blaze/regex.py
@@ -57,7 +57,8 @@ class RegexDispatcher(object):
         return _
 
     def dispatch(self, s):
-        funcs = [func for r, func in self.funcs.items() if re.match(r, s)]
+        funcs = [func for r, func in self.funcs.items()
+                      if re.match(r, s, re.IGNORECASE)]
         return max(funcs, key=self.priorities.get)
 
     def __call__(self, s, *args, **kwargs):

--- a/blaze/tests/test_regex.py
+++ b/blaze/tests/test_regex.py
@@ -25,3 +25,19 @@ def test_regex_dispatcher():
     assert foo('123') == 123
     assert foo('hello') == 'hello'
     assert foo('0123') == '0123'
+
+
+def test_case_insensitivity():
+    foo = RegexDispatcher('foo')
+
+    @foo.register('foo')
+    def a(s):
+        return 'foo'
+
+    @foo.register('.*', priority=0)
+    def b(s):
+        return 'bar'
+
+    assert foo('hello') == 'bar'
+    assert foo('foo') == 'foo'
+    assert foo('FOO') == 'foo'


### PR DESCRIPTION
All resource URIs are checked against the collection of regular expressions
in a case insensitive way.

This simplifies the creation of `resource` functions
(e.g. can say `'.*\.csv'` rather than `'.*\.(csv|CSV)'` but limits
discrimination power a bit.
