### PR TITLE
Allows the blaze server to stream results back

### DIFF
--- a/blaze/compatibility.py
+++ b/blaze/compatibility.py
@@ -60,6 +60,20 @@ if PY2:
         return MethodType(func, instance, type(instance))
 
     from itertools import izip_longest as zip_longest
+
+    from abc import ABCMeta
+    import collections
+    from types import ModuleType
+    collections_abc = ModuleType('compatibility.abc')
+    for k, v in vars(collections).items():
+        # Construct a collections.abc module with the abc's from collections.
+        if isinstance(v, ABCMeta):
+            setattr(collections_abc, k, v)
+    del ABCMeta
+    del ModuleType
+    del collections
+    del k
+    del v
 else:
     _inttypes = (int,)
     _strtypes = (str,)
@@ -68,6 +82,7 @@ else:
     boundmethod = MethodType
 
     from itertools import zip_longest
+    from collections import abc as collections_abc
 
 
 import io

--- a/blaze/compatibility.py
+++ b/blaze/compatibility.py
@@ -60,20 +60,6 @@ if PY2:
         return MethodType(func, instance, type(instance))
 
     from itertools import izip_longest as zip_longest
-
-    from abc import ABCMeta
-    import collections
-    from types import ModuleType
-    collections_abc = ModuleType('compatibility.abc')
-    for k, v in vars(collections).items():
-        # Construct a collections.abc module with the abc's from collections.
-        if isinstance(v, ABCMeta):
-            setattr(collections_abc, k, v)
-    del ABCMeta
-    del ModuleType
-    del collections
-    del k
-    del v
 else:
     _inttypes = (int,)
     _strtypes = (str,)
@@ -82,7 +68,6 @@ else:
     boundmethod = MethodType
 
     from itertools import zip_longest
-    from collections import abc as collections_abc
 
 
 import io

--- a/blaze/server/__init__.py
+++ b/blaze/server/__init__.py
@@ -9,6 +9,7 @@ from .serialization import (
     json as json_format,
     pickle as pickle_format,
     msgpack as msgpack_format,
+    stream_formats,
 )
 
 
@@ -24,5 +25,6 @@ __all__ = [
     'json_format',
     'msgpack_format',
     'pickle_format',
+    'stream_formats',
     'to_tree',
 ]

--- a/blaze/server/client.py
+++ b/blaze/server/client.py
@@ -89,10 +89,9 @@ class Client(object):
     auth : tuple, optional
         The username and password to use when connecting to the server.
         If not provided, no auth header will be sent.
-
     chunksize : int, optional
         The size of the chunks to use on the server when making queries.
-        If this value is <= 0 then no chunking will be used.
+        If this is None, then no chunking will be used.
 
     Examples
     --------

--- a/blaze/server/client.py
+++ b/blaze/server/client.py
@@ -1,10 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 import warnings
-from contextlib import closing
-
-import flask
-import requests
 
 from datashape import dshape
 import flask
@@ -16,7 +12,7 @@ from requests.packages.urllib3.exceptions import InsecureRequestWarning
 from ..expr import Expr
 from ..dispatch import dispatch
 from .server import DEFAULT_PORT
-from .serialization import json, msgpack
+from .serialization import json
 
 # These are a hack for testing
 # It's convenient to use requests for live production but use

--- a/blaze/server/serialization.py
+++ b/blaze/server/serialization.py
@@ -22,18 +22,51 @@ def _coerce_str(bytes_or_str):
     return bytes_or_str.decode('utf-8')
 
 
-class OutOfData(Exception):
+class OutOfData(StopIteration):
+    """An exception used to indicate that a lazy unpacker does not have
+    enough data to return an object.
+    """
     pass
 
 
 class JsonUnpacker(object):
-    def __init__(self):
-        self._buffer = bytearray()
+    """A class for consuming a stream of bytes yielding json objects as they
+    are read.
+
+    Objects may be extracted with either the ``unpack`` method or the
+    iteration protocol.
+
+    Parameters
+    ----------
+    buffer_ : bytearray, optional
+        The initial buffer to consume from.
+    """
+    def __init__(self, buffer_=None):
+        self._buffer = bytearray() if buffer_ is None else buffer_
 
     def feed(self, next_bytes):
+        """Feed new data into the unpacker.
+
+        Parameters
+        ----------
+        next_bytes : bytes
+            New bytes to append to our internal buffer.
+        """
         self._buffer.extend(next_bytes)
 
     def unpack(self):
+        """Consume one json object from our buffer.
+
+        Returns
+        -------
+        obj : any
+            The first json object in our buffer if any exists.
+
+        Raises
+        ------
+        OutOfData
+            If there is not enough data in the buffer to return an object.
+        """
         buffer_ = self._buffer
         loads = json_module.loads
         for n in range(len(buffer_) + 1):

--- a/blaze/server/serialization.py
+++ b/blaze/server/serialization.py
@@ -8,7 +8,12 @@ from ..compatibility import pickle as pickle_module, unicode
 from ..utils import json_dumps
 
 
-SerializationFormat = namedtuple('SerializationFormat', 'name loads dumps')
+class SerializationFormat(namedtuple(
+        'SerializationFormat', 'name loads dumps stream_unpacker')):
+    def __new__(_cls, name, loads, dumps, stream_unpacker=None):
+        return super(SerializationFormat, _cls).__new__(
+            _cls, name, loads, dumps, stream_unpacker,
+        )
 
 
 def _coerce_str(bytes_or_str):
@@ -17,10 +22,31 @@ def _coerce_str(bytes_or_str):
     return bytes_or_str.decode('utf-8')
 
 
+class JsonUnpacker(object):
+    def __init__(self):
+        self._buffer = bytearray()
+
+    def feed(self, next_bytes):
+        self._buffer.extend(next_bytes)
+
+    def __iter__(self):
+        buffer_ = self._buffer
+        loads = json_module.loads
+        for n in range(len(buffer_) + 1):
+            try:
+                obj = loads(buffer_[:n].decode('utf-8'))
+            except ValueError:
+                continue
+
+            self._buffer = buffer_ = buffer_[n:]
+            yield obj
+
+
 json = SerializationFormat(
     'json',
     lambda data: json_module.loads(_coerce_str(data)),
     partial(json_module.dumps, default=json_dumps),
+    JsonUnpacker,
 )
 pickle = SerializationFormat(
     'pickle',
@@ -31,11 +57,15 @@ msgpack = SerializationFormat(
     'msgpack',
     partial(msgpack_module.unpackb, encoding='utf-8'),
     partial(msgpack_module.packb, default=json_dumps),
+    msgpack_module.Unpacker,
 )
 
 
 all_formats = frozenset(
     g for _, g in globals().items() if isinstance(g, SerializationFormat)
+)
+stream_formats = frozenset(
+    f for f in all_formats if f.stream_unpacker is not None
 )
 
 

--- a/blaze/server/server.py
+++ b/blaze/server/server.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+from collections import Iterable
 import socket
 import functools
 import re
@@ -31,7 +32,6 @@ from blaze.compute import compute_up
 
 from .serialization import json, all_formats
 from ..interactive import InteractiveSymbol, coerce_scalar
-from ..compatibility import collections_abc
 from ..expr import Expr, symbol
 
 
@@ -428,7 +428,7 @@ def compserver():
         return e.astuple
 
     if streaming:
-        if isinstance(result, collections_abc.Iterable):
+        if isinstance(result, Iterable):
             def gen(_dumps=serial.dumps):
                 for block in result:
                     yield _dumps(block)

--- a/docs/source/whatsnew/0.8.4.txt
+++ b/docs/source/whatsnew/0.8.4.txt
@@ -1,0 +1,44 @@
+Release |version|
+-----------------
+
+:Release: |version|
+:Date: TBD
+
+New Expressions
+~~~~~~~~~~~~~~~
+
+None
+
+Improved Expressions
+~~~~~~~~~~~~~~~~~~~~
+
+None
+
+New Backends
+~~~~~~~~~~~~
+
+Improved Backends
+~~~~~~~~~~~~~~~~~
+
+None
+
+API Changes
+~~~~~~~~~~~
+
+* Blaze server now serves a new ``/compute/stream`` endpoint that uses
+  streaming requests. This can be used with
+  :class:`~blaze.server.client.Client` by passing a new ``chunksize`` argument
+  or with the server REST API by passing the chunk size as a query param.
+  (:issue:` #1146`)
+
+None
+
+Bug Fixes
+~~~~~~~~~
+
+None
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+None


### PR DESCRIPTION
Currently, the server always pulls the response into memory before serializing; however, this is not needed, we can send the result over in chunks.

This uses a new keyword: `chunksize` for the client. When `chunksize > 0`, the server will be instructed to chunk the response so that it is more memory efficient in some cases. This allows the client to decide which API to use.

Some questions I would like to bring up, why does the `compute.<serial_format>` endpoint return the shape and colnames when it is not needed by the client? Could we instead make an endpoint like: `/bokeh/compute` that lives in a seperate `flask.BluePrint` so that bokeh users can opt-in to these other endpoints at the cost of memory inefficiencies on the server. I think `dask` might also use the server (or there was an issue discussing this). Maybe we could have a similar `/dask/compute` endpoint. This also allows us to be more liquid with the server/client API without worrying about breaking other projects.