### PR TITLE
Relabel fix

### DIFF
--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -686,6 +686,7 @@ def post_compute(t, s, **kwargs):
 
 @dispatch(ReLabel, Selectable)
 def compute_up(t, s, **kwargs):
+    s = s.alias()
     columns = [getattr(s.c, col).label(new_col)
                if col != new_col else
                getattr(s.c, col)

--- a/docs/source/whatsnew/0.8.3.txt
+++ b/docs/source/whatsnew/0.8.3.txt
@@ -69,3 +69,5 @@ Bug Fixes
   (:issue:`1207`)
 * Fixed a bug where the wrong value was being passed into
   :func:`~blaze.expr.datetime.time` (:issue:`1213`)
+* Fixed a bug in sql relabel that prevented relabeling anything that generated
+  a subselect. (:issue:`1216`)


### PR DESCRIPTION
Broken expression:

```python
In [1]: ds = bz.Data(resource('postgresql://localhost/bz::ds', schema='vnd'))

In [2]: ds.dshape
Out[2]: 
dshape("""var * {
  asof_date: ?datetime,
  value: ?float64,
  symbol: ?string,
  knowledge_date: ?datetime,
  sid: ?int64
  }""")

In [3]: ds[['value', 'sid']].relabel(value='test')
Out[3]: ---------------------------------------------------------------------------
ProgrammingError                          Traceback (most recent call last)
    ...
ProgrammingError: (psycopg2.ProgrammingError) subquery in FROM must have an alias
LINE 2: FROM (SELECT vnd.ds.value AS value, vnd.ds.sid AS sid 
             ^
HINT:  For example, FROM (SELECT ...) [AS] foo.
 [SQL: 'SELECT value AS test, sid \nFROM (SELECT vnd.ds.value AS value, vnd.ds.sid AS sid \nFROM vnd.ds) \n LIMIT %(param_1)s'] [parameters: {'param_1': 11}]
```