### PR TITLE
Join type promotion

### DIFF
--- a/blaze/compute/python.py
+++ b/blaze/compute/python.py
@@ -535,15 +535,40 @@ def compute_up(t, seq, **kwargs):
     return tuple(keyfunc(k) + valfunc(v) for k, v in d.items())
 
 
-def pair_assemble(t, on_left, on_right):
+def pair_assemble(t, on_left=None, on_right=None):
     """ Combine a pair of records into a single record
 
     This is mindful to shared columns as well as missing records
+
+    Parameters
+    ----------
+    t : Join
+        The join to combine.
+    on_left : list of column indicies, optional
+        The column indicies of the left columns.
+    on_right : list of column indicies, optional
+        The column indicies of the right columns.
+
+    Returns
+    -------
+    assemble : callable
+        A function that assembles the data from a row of the
+        left and right data sources.
     """
     try:
         from cytoolz import get  # not curried version
     except:
         from toolz import get
+    on_left = (
+        on_left
+        if on_left is not None else
+        [t.lhs.fields.index(col) for col in listpack(t.on_left)]
+    )
+    on_right = (
+        on_right
+        if on_right is not None else
+        [t.rhs.fields.index(col) for col in listpack(t.on_right)]
+    )
 
     left_self_columns = [t.lhs.fields.index(c) for c in t.lhs.fields
                          if c not in listpack(t.on_left)]

--- a/blaze/compute/python.py
+++ b/blaze/compute/python.py
@@ -535,7 +535,7 @@ def compute_up(t, seq, **kwargs):
     return tuple(keyfunc(k) + valfunc(v) for k, v in d.items())
 
 
-def pair_assemble(t):
+def pair_assemble(t, on_left, on_right):
     """ Combine a pair of records into a single record
 
     This is mindful to shared columns as well as missing records
@@ -544,8 +544,6 @@ def pair_assemble(t):
         from cytoolz import get  # not curried version
     except:
         from toolz import get
-    on_left = [t.lhs.fields.index(col) for col in listpack(t.on_left)]
-    on_right = [t.rhs.fields.index(col) for col in listpack(t.on_right)]
 
     left_self_columns = [t.lhs.fields.index(c) for c in t.lhs.fields
                          if c not in listpack(t.on_left)]
@@ -556,12 +554,9 @@ def pair_assemble(t):
         a, b = pair
         if a is not None:
             joined = get(on_left, a)
-        else:
-            joined = get(on_right, b)
-
-        if a is not None:
             left_entries = get(left_self_columns, a)
         else:
+            joined = get(on_right, b)
             left_entries = (None,) * (len(t.lhs.fields) - len(on_left))
 
         if b is not None:
@@ -603,7 +598,7 @@ def compute_up(t, lhs, rhs, **kwargs):
                        left_default=left_default,
                        right_default=right_default)
 
-    assemble = pair_assemble(t)
+    assemble = pair_assemble(t, on_left, on_right)
 
     return map(assemble, pairs)
 

--- a/blaze/compute/python.py
+++ b/blaze/compute/python.py
@@ -554,9 +554,12 @@ def pair_assemble(t, on_left, on_right):
         a, b = pair
         if a is not None:
             joined = get(on_left, a)
-            left_entries = get(left_self_columns, a)
         else:
             joined = get(on_right, b)
+
+        if a is not None:
+            left_entries = get(left_self_columns, a)
+        else:
             left_entries = (None,) * (len(t.lhs.fields) - len(on_left))
 
         if b is not None:

--- a/blaze/compute/spark.py
+++ b/blaze/compute/spark.py
@@ -150,7 +150,7 @@ def spark_join(t, lhs, rhs, **kwargs):
                          "{'inner', 'left', 'right', 'outer'}" % how)
 
     rdd = joiner(rhs)
-    assemble = pair_assemble(t, on_left, on_right)
+    assemble = pair_assemble(t)
 
     return rdd.map(lambda x: assemble(x[1]))
 

--- a/blaze/compute/spark.py
+++ b/blaze/compute/spark.py
@@ -150,7 +150,7 @@ def spark_join(t, lhs, rhs, **kwargs):
                          "{'inner', 'left', 'right', 'outer'}" % how)
 
     rdd = joiner(rhs)
-    assemble = pair_assemble(t)
+    assemble = pair_assemble(t, on_left, on_right)
 
     return rdd.map(lambda x: assemble(x[1]))
 

--- a/blaze/compute/tests/test_pandas_compute.py
+++ b/blaze/compute/tests/test_pandas_compute.py
@@ -311,6 +311,20 @@ def test_join_suffixes():
     tm.assert_frame_equal(result, expected)
 
 
+def test_join_promotion():
+    a_data = pd.DataFrame([[0.0, 1.5], [1.0, 2.5]], columns=list('ab'))
+    b_data = pd.DataFrame([[0, 1], [1, 2]], columns=list('ac'))
+    a = symbol('a', discover(a_data))
+    b = symbol('b', discover(b_data))
+
+    joined = join(a, b, 'a')
+    assert joined.dshape == dshape('var * {a: float64, b: ?float64, c: int64}')
+
+    expected = pd.merge(a_data, b_data, on='a')
+    result = compute(joined, {a: a_data, b: b_data})
+    tm.assert_frame_equal(result, expected)
+
+
 def test_sort():
     tm.assert_frame_equal(compute(t.sort('amount'), df),
                           df.sort('amount'))

--- a/blaze/compute/tests/test_python_compute.py
+++ b/blaze/compute/tests/test_python_compute.py
@@ -358,16 +358,28 @@ def test_graph_double_join():
     t_arc = symbol('t_arc', 'var * {a: int32, b: int32}')
     t_wanted = symbol('t_wanted', 'var * {name: string}')
 
+    # >>> compute(join(t_idx, t_arc, 'b'), {t_idx: idx, t_arc: arc})
+    # [[1, A, 3],
+    #  [1, A, 2],
+    #  [1, A, 5],
+    #  [3, C, 1],
+    #  [3, C, 2],
+    #  [3, C, 4],
+    #  [3, C, 5],
+    #  [6, F, 1],
+    #  [6, F, 2],
+    #  [6, F, 4]]
+
     j = join(join(t_idx, t_arc, 'b'), t_wanted, 'name')[['name', 'b', 'a']]
 
     result = compute(j, {t_idx: idx, t_arc: arc, t_wanted: wanted})
     result = sorted(map(tuple, result))
-    expected = sorted([('A', 3, 1),
-                       ('A', 2, 1),
-                       ('A', 5, 1),
-                       ('F', 1, 6),
-                       ('F', 2, 6),
-                       ('F', 4, 6)])
+    expected = sorted([('A', 1, 3),
+                       ('A', 1, 2),
+                       ('A', 1, 5),
+                       ('F', 6, 1),
+                       ('F', 6, 2),
+                       ('F', 6, 4)])
 
     assert result == expected
 

--- a/blaze/compute/tests/test_python_compute.py
+++ b/blaze/compute/tests/test_python_compute.py
@@ -363,11 +363,11 @@ def test_graph_double_join():
     result = compute(j, {t_idx: idx, t_arc: arc, t_wanted: wanted})
     result = sorted(map(tuple, result))
     expected = sorted([('A', 3, 1),
-                    ('A', 2, 1),
-                    ('A', 5, 1),
-                    ('F', 1, 6),
-                    ('F', 2, 6),
-                    ('F', 4, 6)])
+                       ('A', 2, 1),
+                       ('A', 5, 1),
+                       ('F', 1, 6),
+                       ('F', 2, 6),
+                       ('F', 4, 6)])
 
     assert result == expected
 

--- a/blaze/expr/collections.py
+++ b/blaze/expr/collections.py
@@ -452,13 +452,13 @@ class Join(Expr):
 
         right_types = keymap(
             dict(zip(on_right, on_left)).get,
-            dict(self.rhs.schema[0].parameters[0]),
+            self.rhs.dshape.measure.dict,
         )
         joined = (
             (name, promote(dt, right_types[name], promote_option=False))
             for n, (name, dt) in enumerate(filter(
                 compose(op.contains(on_left), first),
-                self.lhs.schema[0].parameters[0]
+                self.lhs.dshape.measure.fields,
             ))
         )
 

--- a/blaze/expr/collections.py
+++ b/blaze/expr/collections.py
@@ -556,7 +556,7 @@ def join(lhs, rhs, on_left=None, on_right=None,
                                       left_types,
                                       right_types)):
         if promotion == object_:
-            raise TypeError(
+            raise ValueError(
                 "Schema's of joining columns do not match,"
                 ' no promotion found for %s=%s and %s=%s' % (
                     on_left[n], left_types[n], on_right[n], right_types[n],

--- a/blaze/expr/collections.py
+++ b/blaze/expr/collections.py
@@ -547,7 +547,7 @@ def join(lhs, rhs, on_left=None, on_right=None,
     right_types = listpack(types_of_fields(on_right, rhs))
     if len(left_types) != len(right_types):
         raise ValueError(
-            'Length of on_left=%d not equal to lenght of on_right=%d' % (
+            'Length of on_left=%d not equal to length of on_right=%d' % (
                 len(left_types), len(right_types),
             ),
         )

--- a/blaze/expr/collections.py
+++ b/blaze/expr/collections.py
@@ -450,9 +450,8 @@ class Join(Expr):
         if not isinstance(on_right, list):
             on_right = on_right,
 
-        mapping = dict(zip(on_right, on_left))
         right_types = keymap(
-            lambda k: mapping.get(k),
+            dict(zip(on_right, on_left)).get,
             dict(self.rhs.schema[0].parameters[0]),
         )
         joined = (

--- a/blaze/expr/tests/test_collections.py
+++ b/blaze/expr/tests/test_collections.py
@@ -91,6 +91,28 @@ def test_join_option_types():
     assert join(b, a, 'x').dshape == dshape('var * {x: int}')
 
 
+def test_join_mismatched_schema():
+    a = symbol('a', 'var * {x: int}')
+    b = symbol('b', 'var * {x: string}')
+
+    with pytest.raises(TypeError):
+        join(a, b, 'x')
+
+
+def test_join_type_promotion():
+    a = symbol('a', 'var * {x: int32}')
+    b = symbol('b', 'var * {x: int64}')
+
+    assert join(a, b, 'x').dshape == dshape('var * {x: int64}')
+
+
+def test_join_type_promotion_option():
+    a = symbol('a', 'var * {x: ?int32}')
+    b = symbol('b', 'var * {x: int64}')
+
+    assert join(a, b, 'x').dshape == dshape('var * {x: int64}')
+
+
 def test_isin():
     a = symbol('a', 'var * {x: int, y: string}')
     assert hasattr(a.x, 'isin')

--- a/blaze/expr/tests/test_collections.py
+++ b/blaze/expr/tests/test_collections.py
@@ -83,6 +83,14 @@ def test_raise_error_if_join_on_no_columns():
     assert raises(ValueError, lambda: join(a, b))
 
 
+def test_join_option_types():
+    a = symbol('a', 'var * {x: ?int}')
+    b = symbol('b', 'var * {x: int}')
+
+    assert join(a, b, 'x').dshape == dshape('var * {x: int}')
+    assert join(b, a, 'x').dshape == dshape('var * {x: int}')
+
+
 def test_isin():
     a = symbol('a', 'var * {x: int, y: string}')
     assert hasattr(a.x, 'isin')

--- a/blaze/expr/tests/test_collections.py
+++ b/blaze/expr/tests/test_collections.py
@@ -95,7 +95,7 @@ def test_join_mismatched_schema():
     a = symbol('a', 'var * {x: int}')
     b = symbol('b', 'var * {x: string}')
 
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         join(a, b, 'x')
 
 

--- a/blaze/expr/tests/test_table.py
+++ b/blaze/expr/tests/test_table.py
@@ -241,7 +241,7 @@ def test_join():
     assert join(t, s, 'name').on_right == 'name'
 
     assert join(t, r, ('name', 'amount')).on_left == ['name', 'amount']
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         join(t, q, 'name')
     with pytest.raises(ValueError):
         join(t, s, how='upside_down')

--- a/docs/source/whatsnew/0.8.3.txt
+++ b/docs/source/whatsnew/0.8.3.txt
@@ -20,9 +20,10 @@ Improved Expressions
   parameter to allow distinct on a subset of columns (:issue:`1159`)
 * :class:`~blaze.expr.reductions.Reduction` instances are now named as their
   class name if their ``_child`` attribute is named ``'_'`` (:issue:`1198`)
-* :class:`~blaze.expr.collections.Join` expressions now support joining types
-  against their corrosponding optional type (eg. ``int`` -> ``?int``)
-  (:issue:`1193`, :issue:`1218`).
+* :class:`~blaze.expr.collections.Join` expressions now promotes the types of
+  the fields being joined on. This allows us to join things like ``int32``
+  and ``int64`` and have the result be an int64. This also allows us to join
+  any type ``a`` with ``?a``. (:issue:`1193`, :issue:`1218`).
 
 New Backends
 ~~~~~~~~~~~~

--- a/docs/source/whatsnew/0.8.3.txt
+++ b/docs/source/whatsnew/0.8.3.txt
@@ -20,6 +20,9 @@ Improved Expressions
   parameter to allow distinct on a subset of columns (:issue:`1159`)
 * :class:`~blaze.expr.reductions.Reduction` instances are now named as their
   class name if their ``_child`` attribute is named ``'_'`` (:issue:`1198`)
+* :class:`~blaze.expr.collections.Join` expressions now support joining types
+  against their corrosponding optional type (eg. ``int`` -> ``?int``)
+  (:issue:`1193`, :issue:`1218`).
 
 New Backends
 ~~~~~~~~~~~~


### PR DESCRIPTION
closes #1193

__edit__: this pr also does generic type promotion of joined fields.

needs https://github.com/blaze/datashape/pull/172

This also fixes an issue that could occur when joining on a single column name passed as a string when other column names were substrings of the join column.