### PR TITLE
Fix group by when optimized common subexpression isn't a subsetted DataFrame but appears to be one when the expression is written down

### DIFF
--- a/blaze/compute/pandas.py
+++ b/blaze/compute/pandas.py
@@ -360,7 +360,7 @@ def compute_by(t, s, g, df):
 
     if not df.index.equals(preapply.index):
         df = df.loc[preapply.index]
-    df2 = concat_nodup(df.loc[preapply.index], preapply)
+    df2 = concat_nodup(df, preapply)
 
     groups = df2.groupby(g)
 

--- a/blaze/compute/pandas.py
+++ b/blaze/compute/pandas.py
@@ -358,7 +358,9 @@ def compute_by(t, s, g, df):
                                   [compute(v._child, {t._child: df})
                                    for v in one.values])))
 
-    df2 = concat_nodup(df, preapply)
+    if not df.index.equals(preapply.index):
+        df = df.loc[preapply.index]
+    df2 = concat_nodup(df.loc[preapply.index], preapply)
 
     groups = df2.groupby(g)
 

--- a/blaze/compute/tests/test_bcolz_compute.py
+++ b/blaze/compute/tests/test_bcolz_compute.py
@@ -7,7 +7,10 @@ from datashape import discover, dshape
 
 import numpy as np
 
+import pandas.util.testing as tm
+
 from odo import into
+from blaze import by
 from blaze.expr import symbol
 from blaze.compute.core import compute, pre_compute
 from blaze.compute.bcolz import get_chunksize
@@ -161,3 +164,13 @@ def test_chunksize_inference():
 def test_notnull():
     with pytest.raises(AttributeError):
         t.b.notnull
+
+
+def test_by_with_single_row():
+    ct = bcolz.ctable([[1, 1, 3, 3], [1, 2, 3, 4]], names=list('ab'))
+    t = symbol('t', discover(ct))
+    subset = t[t.a == 3]
+    expr = by(subset.a, b_sum=subset.b.sum())
+    result = compute(expr, ct)
+    expected = compute(expr, ct, optimize=False)
+    tm.assert_frame_equal(result, expected)

--- a/blaze/expr/optimize.py
+++ b/blaze/expr/optimize.py
@@ -64,7 +64,7 @@ def _lean(expr, fields=None):
 
 @dispatch(Arithmetic)
 def _lean(expr, fields=None):
-    lhs, right_fields  = _lean(expr.lhs, fields=())
+    lhs, right_fields = _lean(expr.lhs, fields=())
     rhs, left_fields = _lean(expr.rhs, fields=())
     new_fields = set(fields) | set(left_fields) | set(right_fields)
 

--- a/docs/source/whatsnew/0.8.3.txt
+++ b/docs/source/whatsnew/0.8.3.txt
@@ -87,5 +87,7 @@ Bug Fixes
   :func:`~blaze.expr.datetime.time` (:issue:`1213`)
 * Fixed a bug in sql relabel that prevented relabeling anything that generated
   a subselect. (:issue:`1216`)
-* Fixed a bug where methods weren't accesssible on fields with the same
+* Fixed a bug where methods weren't accessible on fields with the same
   name (:issue:`1204`)
+* Fixed a bug where optimized expressions going into a pandas group by were
+  incorrectly assigning extra values to the child DataFrame (:issue:`1221`)


### PR DESCRIPTION
closes #1221