### PR TITLE
Update rosetta-pandas.rst

### DIFF
--- a/docs/source/rosetta-pandas.rst
+++ b/docs/source/rosetta-pandas.rst
@@ -107,8 +107,6 @@ Blaze can simplify and make more readable some common IO tasks that one would wa
 +-----------------+-----------------------------------------------------------------+---------------------------------------------------+
 | Read from       | .. code-block:: python                                          | .. code-block:: python                            |
 | SQL database    |                                                                 |                                                   |
-|                 |    import sqlalchemy as sa                                      |    df = Data('sqlite://db.db::t')                 |
-|                 |    engine = sa.create_engine('sqlite://db.db')                  |                                                   |
-|                 |    df = pd.read_sql('select * from t',                          |                                                   |
-|                 |                     con=engine)                                 |                                                   |
+|                 |    df = pd.read_sql('select * from t',                          |    df = Data('sqlite://db.db::t')                 |
+|                 |        con='sqlite://db.db')                                    |                                                   |
 +-----------------+-----------------------------------------------------------------+---------------------------------------------------+


### PR DESCRIPTION
According https://github.com/pydata/pandas/issues/10654
read from SQL database is now easier with Pandas 0.17 than it was previously

Instead of

```
import sqlalchemy as sa
engine = sa.create_engine('sqlite://db.db')
df = pd.read_sql('select * from t',
                 con=engine)
```

we can do

```
df = pd.read_sql('select * from t',
    con='sqlite://db.db')
```