### PR TITLE
Fix for issue #1240.

### DIFF
--- a/blaze/expr/core.py
+++ b/blaze/expr/core.py
@@ -291,7 +291,8 @@ def _str(s):
     elif isinstance(s, Node):
         return str(s)
     elif isinstance(s, (list, tuple)):
-        return tuple(_str(x) for x in s)
+        body = ", ".join(_str(x) for x in s)
+        return "({})".format(body if len(s) > 1 else (body + ","))
     else:
         stream = StringIO()
         pprint(s, stream=stream)

--- a/blaze/expr/core.py
+++ b/blaze/expr/core.py
@@ -292,7 +292,7 @@ def _str(s):
         return str(s)
     elif isinstance(s, (list, tuple)):
         body = ", ".join(_str(x) for x in s)
-        return "({})".format(body if len(s) > 1 else (body + ","))
+        return "({0})".format(body if len(s) > 1 else (body + ","))
     else:
         stream = StringIO()
         pprint(s, stream=stream)

--- a/blaze/expr/core.py
+++ b/blaze/expr/core.py
@@ -290,6 +290,8 @@ def _str(s):
         return get_callable_name(s)
     elif isinstance(s, Node):
         return str(s)
+    elif isinstance(s, (list, tuple)):
+        return tuple(_str(x) for x in s)
     else:
         stream = StringIO()
         pprint(s, stream=stream)

--- a/blaze/tests/test_interactive.py
+++ b/blaze/tests/test_interactive.py
@@ -1,9 +1,10 @@
 from blaze.interactive import Data, compute, concrete_head, expr_repr, to_html
 
 import datetime
+from re import sub
 from odo import into, append
 from odo.backends.csv import CSV
-from blaze import discover
+from blaze import discover, transform
 from blaze.compute.core import compute
 from blaze.compute.python import compute
 from blaze.expr import symbol
@@ -92,6 +93,13 @@ def test_repr():
     print(result)
     assert len(result.split('\n')) < 20
     assert '...' in result
+
+
+def test_str_does_not_repr():
+    # see GH issue #1240.
+    d = Data([('aa', 1), ('b', 2)], dshape='2 * {a: string, b: int64}')
+    expr = transform(d, c=d.a.strlen() + d.b)
+    assert sub(r'_\d+', 'XXX', str(expr)) == "Merge(_child=XXX, children=(XXX, label(strlen(_child=XXX.a) + XXX.b, 'c')))"
 
 
 def test_repr_of_scalar():

--- a/blaze/tests/test_interactive.py
+++ b/blaze/tests/test_interactive.py
@@ -12,7 +12,6 @@ from blaze.utils import tmpfile, example
 from blaze.compatibility import xfail
 import pytest
 import sys
-import re
 from types import MethodType
 
 import pandas as pd
@@ -97,9 +96,9 @@ def test_repr():
 
 def test_str_does_not_repr():
     # see GH issue #1240.
-    d = Data([('aa', 1), ('b', 2)], dshape='2 * {a: string, b: int64}')
+    d = Data([('aa', 1), ('b', 2)], name="ZZZ", dshape='2 * {a: string, b: int64}')
     expr = transform(d, c=d.a.strlen() + d.b)
-    assert re.sub(r'_\d+', 'XXX', str(expr)) == "Merge(_child=XXX, children=(XXX, label(strlen(_child=XXX.a) + XXX.b, 'c')))"
+    assert str(expr) == "Merge(_child=ZZZ, children=(ZZZ, label(strlen(_child=ZZZ.a) + ZZZ.b, 'c')))"
 
 
 def test_repr_of_scalar():

--- a/blaze/tests/test_interactive.py
+++ b/blaze/tests/test_interactive.py
@@ -1,7 +1,6 @@
 from blaze.interactive import Data, compute, concrete_head, expr_repr, to_html
 
 import datetime
-from re import sub
 from odo import into, append
 from odo.backends.csv import CSV
 from blaze import discover, transform
@@ -13,6 +12,7 @@ from blaze.utils import tmpfile, example
 from blaze.compatibility import xfail
 import pytest
 import sys
+import re
 from types import MethodType
 
 import pandas as pd
@@ -99,7 +99,7 @@ def test_str_does_not_repr():
     # see GH issue #1240.
     d = Data([('aa', 1), ('b', 2)], dshape='2 * {a: string, b: int64}')
     expr = transform(d, c=d.a.strlen() + d.b)
-    assert sub(r'_\d+', 'XXX', str(expr)) == "Merge(_child=XXX, children=(XXX, label(strlen(_child=XXX.a) + XXX.b, 'c')))"
+    assert re.sub(r'_\d+', 'XXX', str(expr)) == "Merge(_child=XXX, children=(XXX, label(strlen(_child=XXX.a) + XXX.b, 'c')))"
 
 
 def test_repr_of_scalar():


### PR DESCRIPTION
Calling `_str()` on a tuple of expressions triggers a `__repr__` call on
each element, resulting in unnecessary computation.

This fix detects when stringifying a tuple of exprs, and calls `_str()`
recursively in that case.