### PR TITLE
BUG: don't unpack options in schema_concat

### DIFF
--- a/blaze/expr/collections.py
+++ b/blaze/expr/collections.py
@@ -256,21 +256,17 @@ def schema_concat(exprs):
 
     In the case of Units, the name is taken from expr.name
     """
-    names, values = [], []
+    new_fields = []
     for c in exprs:
         schema = c.schema[0]
-        if isinstance(schema, Option):
-            schema = schema.ty
         if isinstance(schema, Record):
-            names.extend(schema.names)
-            values.extend(schema.types)
-        elif isinstance(schema, Unit):
-            names.append(c._name)
-            values.append(schema)
+            new_fields.extend(schema.fields)
+        elif isinstance(schema, (Unit, Option)):
+            new_fields.append((c._name, schema))
         else:
             raise TypeError("All schemas must have Record or Unit shape."
-                            "\nGot %s" % c.schema[0])
-    return dshape(Record(list(zip(names, values))))
+                            "\nGot %s" % schema)
+    return dshape(Record(new_fields))
 
 
 class Merge(ElemWise):

--- a/blaze/expr/tests/test_collections.py
+++ b/blaze/expr/tests/test_collections.py
@@ -1,6 +1,7 @@
 import pytest
 
 from datashape import dshape
+from datashape.util.testing import assert_dshape_equal
 
 from blaze.expr import symbol
 from blaze.expr.collections import merge, join, transform, concat
@@ -18,6 +19,15 @@ def test_merge():
 
     assert set(expr.fields) == set(['name', 'y'])
     assert expr.y.isidentical(e.x.label('y'))
+
+
+def test_merge_options():
+    s = symbol('s', 'var * {a: ?A, b: ?B}')
+
+    merged = merge(a=s.a, b=s.b)
+    assert_dshape_equal(merged.dshape, dshape('var * {a: ?A, b: ?B}'))
+    assert_dshape_equal(merged.a.dshape, dshape('var * ?A'))
+    assert_dshape_equal(merged.b.dshape, dshape('var * ?B'))
 
 
 def test_merge_on_single_argument_is_noop():

--- a/docs/source/whatsnew/0.8.4.txt
+++ b/docs/source/whatsnew/0.8.4.txt
@@ -1,0 +1,37 @@
+Release |version|
+-----------------
+
+:Release: |version|
+:Date: TBD
+
+New Expressions
+~~~~~~~~~~~~~~~
+
+None
+
+Improved Expressions
+~~~~~~~~~~~~~~~~~~~~
+
+None
+
+New Backends
+~~~~~~~~~~~~
+
+None
+
+Improved Backends
+~~~~~~~~~~~~~~~~~
+
+None
+
+API Changes
+~~~~~~~~~~~
+
+None
+
+Bug Fixes
+~~~~~~~~~
+
+* Fixed a bug where ``Merge`` expressions would unpack option types in their
+  fields. This could cause you to have a table where ``expr::{a: int32}`` but
+  ``expr.a::?int32``. Note that the dotted acces is an option (:issue:`1262`).


### PR DESCRIPTION
This was causing some strange dshape stuff in transform:

```python
deltas.dshape dshape("var * {sid: ?int64, asof_date: datetime, timestamp: datetime, value: float64}")
deltas.value.dshape dshape("var * ?float64")
```

In the full expr, `value` is not an option type; however, when we pull the column out, it becomes optional. The issue is that `value` in the base expression is dropping the option