### PR TITLE
Fix scalar_coerce for nan->nat

### DIFF
--- a/blaze/interactive.py
+++ b/blaze/interactive.py
@@ -14,7 +14,7 @@ import numpy as np
 from odo import resource, odo
 from odo.utils import ignoring, copydoc
 from odo.compatibility import unicode
-from pandas import DataFrame, Series
+from pandas import DataFrame, Series, Timestamp
 
 
 from .expr import Expr, Symbol, ndim
@@ -239,7 +239,7 @@ def coerce_scalar(result, dshape):
     elif 'bool' in dshape:
         return coerce_to(bool, result)
     elif 'datetime' in dshape:
-        return coerce_to(datetime.datetime, result)
+        return coerce_to(Timestamp, result)
     elif 'date' in dshape:
         return coerce_to(datetime.date, result)
     else:

--- a/blaze/tests/test_interactive.py
+++ b/blaze/tests/test_interactive.py
@@ -367,9 +367,17 @@ def test_coerce_date_and_datetime():
     d = Data(x)
     assert repr(d) == repr(x)
 
-    x = datetime.datetime.now()
+    x = pd.Timestamp.now()
     d = Data(x)
     assert repr(d) == repr(x)
+
+    x = np.nan
+    d = Data(x, dshape='datetime')
+    assert repr(d) == repr(pd.NaT)
+
+    x = float('nan')
+    d = Data(x, dshape='datetime')
+    assert repr(d) == repr(pd.NaT)
 
 
 def test_highly_nested_repr():

--- a/docs/source/whatsnew/0.9.0.txt
+++ b/docs/source/whatsnew/0.9.0.txt
@@ -36,3 +36,6 @@ Bug Fixes
 * Fixed a bug where ``Merge`` expressions would unpack option types in their
   fields. This could cause you to have a table where ``expr::{a: int32}`` but
   ``expr.a::?int32``. Note that the dotted acces is an option (:issue:`1262`).
+* Fixed a bug that prevented creating a
+  :class:`~blaze.interactive.InteractiveSymbol` that wrapped ``nan`` if the
+  dshape was ``datetime``. This now correctly coerces to `NaT` (:issue:`1272`).


### PR DESCRIPTION
This bug also prevented me from taking the min of an empty series of `datetime64` in pandas when using the blaze server because the server was trying to scaler_coerce the `nan` into a `datetime.datetime`.