### PR TITLE
BUG: fix len for interactive exprs that wrap sql

### DIFF
--- a/blaze/compute/tests/test_postgresql_compute.py
+++ b/blaze/compute/tests/test_postgresql_compute.py
@@ -14,7 +14,7 @@ import pandas.util.testing as tm
 
 from odo import odo, resource, drop, discover
 from blaze import symbol, compute, concat, join, sin, cos, radians, atan2
-from blaze import sqrt, transform
+from blaze import sqrt, transform, Data
 from blaze.utils import example
 
 
@@ -321,3 +321,8 @@ def test_coerce_on_select(nyc):
     expected = odo(compute(t, nyc),
                    pd.DataFrame).passenger_count.astype('float64') + 1.0
     assert list(s) == list(expected)
+
+
+def test_interactive_len(sql):
+    t = Data(sql)
+    assert len(t) == int(t.count())

--- a/blaze/interactive.py
+++ b/blaze/interactive.py
@@ -311,7 +311,7 @@ def table_length(expr):
     try:
         return expr._len()
     except ValueError:
-        return compute(expr.count())
+        return int(expr.count())
 
 
 Expr.__repr__ = expr_repr

--- a/docs/source/whatsnew/0.9.0.txt
+++ b/docs/source/whatsnew/0.9.0.txt
@@ -43,3 +43,5 @@ Bug Fixes
 * Fixed an issue where blaze client/server could not use `isin` expressions
   because the ``frozenset`` failed to serialize. This also added support for
   rich serialization over json for things like datetimes (:issue:`1255`).
+* Fixed a bug where ``len`` would fail on an interactive expression whose
+  resources were sqlalchemy objects (:issue:`1273`).


### PR DESCRIPTION
`compute` for the sqlbackend would return a `select`. the `len` machinery would then try to coerce this into an `int` and fail with a type error. 