### PR TITLE
Fix selections that have inner inputs.

### DIFF
--- a/blaze/compute/dask.py
+++ b/blaze/compute/dask.py
@@ -39,8 +39,11 @@ try:
                     *concat((dat, tuple(range(ndim(dat))[::-1])) for dat in data))
 
     def optimize_array(expr, *data):
-        return broadcast_collect(expr, Broadcastable=Broadcastable,
-                                       WantToBroadcast=Broadcastable)
+        return broadcast_collect(
+            expr,
+            broadcastable=Broadcastable,
+            want_to_broadcast=Broadcastable,
+        )
 
     for i in range(5):
         compute_up.register(Broadcast, *([(Array, Number)] * i))(compute_broadcast)

--- a/blaze/compute/mongo.py
+++ b/blaze/compute/mongo.py
@@ -56,17 +56,47 @@ from toolz import pluck, first, get, compose
 import toolz
 import datetime
 
-from ..expr import (Sort, count, nunique, nelements, Selection,
-                    mean, Reduction, Head, ReLabel, Distinct, ElemWise, By,
-                    Symbol, Projection, Field, sum, min, max, Gt, Lt, Ge, Le,
-                    Eq, Ne, And, Or, Summary, Like, Broadcast, DateTime,
-                    Microsecond, Date, Time, Expr, symbol, Arithmetic, floor,
-                    ceil, FloorDiv)
+from ..expr import (
+    And,
+    Arithmetic,
+    Broadcast,
+    By,
+    Distinct,
+    Eq,
+    Expr,
+    Field,
+    FloorDiv,
+    Ge,
+    Gt,
+    Head,
+    Le,
+    Like,
+    Lt,
+    Ne,
+    Or,
+    Projection,
+    Reduction,
+    Selection,
+    SimpleSelection,
+    Sort,
+    Summary,
+    Symbol,
+    ceil,
+    count,
+    floor,
+    math,
+    max,
+    mean,
+    min,
+    nelements,
+    nunique,
+    sum,
+    symbol,
+)
 from ..expr.broadcast import broadcast_collect, Broadcastable
-from ..expr import math
 from ..expr.datetime import Day, Month, Year, Minute, Second, UTCFromTimestamp
+from ..expr.optimize import simple_selections
 from ..compatibility import _strtypes
-
 from ..dispatch import dispatch
 
 
@@ -121,7 +151,7 @@ class MongoQuery(object):
 
 @dispatch(Expr, (MongoQuery, Collection))
 def optimize(expr, seq):
-    return broadcast_collect(expr)
+    return broadcast_collect(simple_selections(expr), no_recurse=SimpleSelection)
 
 
 @dispatch(Head, MongoQuery)
@@ -207,7 +237,7 @@ def compute_up(t, q, **kwargs):
     return q.append({'$project': dict((col, 1) for col in t.fields)})
 
 
-@dispatch(Selection, MongoQuery)
+@dispatch(SimpleSelection, MongoQuery)
 def compute_up(expr, data, **kwargs):
     predicate = optimize(expr.predicate, data)
 

--- a/blaze/compute/numba.py
+++ b/blaze/compute/numba.py
@@ -32,8 +32,11 @@ def optimize_ndarray(expr, *data, **kwargs):
                 for dt in leaf.dshape.measure.types)):
             return expr
     else:
-        return broadcast_collect(expr, Broadcastable=Broadcastable,
-                                 WantToBroadcast=Broadcastable)
+        return broadcast_collect(
+            expr,
+            broadcastable=Broadcastable,
+            want_to_broadcast=Broadcastable,
+        )
 
 
 for i in range(1, 11):

--- a/blaze/compute/numexpr.py
+++ b/blaze/compute/numexpr.py
@@ -59,13 +59,15 @@ def print_numexpr(leaves, expr):
         return '%s%s' % (expr.symbol, parenthesize(child))
     if isinstance(expr, isnan):
         child = print_numexpr(leaves, expr._child)
-        return '%s != %s' % (parenthsize(child), parenthesize(child))
+        return '%s != %s' % (parenthesize(child), parenthesize(child))
     raise NotImplementedError("Operation %s not supported by numexpr" %
                               type(expr).__name__)
 
 
 Broadcastable = WantToBroadcast = BinOp, UnaryOp
 
-broadcast_numexpr_collect = curry(broadcast_collect,
-                                  Broadcastable=Broadcastable,
-                                  WantToBroadcast=WantToBroadcast)
+broadcast_numexpr_collect = curry(
+    broadcast_collect,
+    broadcastable=Broadcastable,
+    want_to_broadcast=WantToBroadcast
+)

--- a/blaze/compute/numpy.py
+++ b/blaze/compute/numpy.py
@@ -270,6 +270,11 @@ def compute_up(sel, x, **kwargs):
     return x[compute(sel.predicate, {sel._child: x})]
 
 
+@dispatch(Selection, np.ndarray, np.ndarray)
+def compute_up(expr, arr, predicate, **kwargs):
+    return arr[predicate]
+
+
 @dispatch(UTCFromTimestamp, np.ndarray)
 def compute_up(expr, data, **kwargs):
     return (data * 1e6).astype('datetime64[us]')

--- a/blaze/compute/pandas.py
+++ b/blaze/compute/pandas.py
@@ -131,8 +131,17 @@ def compute_up(t, df, **kwargs):
 
 
 @dispatch(Selection, (Series, DataFrame))
-def compute_up(t, df, **kwargs):
-    predicate = compute(t.predicate, {t._child: df})
+def compute_up(expr, df, **kwargs):
+    return compute_up(
+        expr,
+        df,
+        compute(expr.predicate, {expr._child: df}),
+        **kwargs
+    )
+
+
+@dispatch(Selection, (Series, DataFrame), Series)
+def compute_up(expr, df, predicate, **kwargs):
     return df[predicate]
 
 

--- a/blaze/compute/pmap.py
+++ b/blaze/compute/pmap.py
@@ -1,10 +1,12 @@
 from __future__ import absolute_import, division, print_function
 
-default_map = [map]
+default_map = map
+
 
 def set_default_pmap(func):
-    default_map[0] = func
+    global default_map
+    default_map = func
 
 
 def get_default_pmap():
-    return default_map[0]
+    return default_map

--- a/blaze/compute/pytables.py
+++ b/blaze/compute/pytables.py
@@ -157,8 +157,11 @@ WantToBroadcast = UnaryOp, BinOp
 
 @dispatch(Expr, tb.Table)
 def optimize(expr, seq):
-    return broadcast_numexpr_collect(expr, Broadcastable=Broadcastable,
-                                     WantToBroadcast=WantToBroadcast)
+    return broadcast_numexpr_collect(
+        expr,
+        broadcastable=Broadcastable,
+        want_to_broadcast=WantToBroadcast,
+    )
 
 
 @dispatch(nelements, tb.Table)

--- a/blaze/compute/pytables.py
+++ b/blaze/compute/pytables.py
@@ -7,8 +7,9 @@ from datashape import Record, from_numpy, datetime_, date_
 
 from blaze.expr import (Selection, Head, Field, Broadcast, Projection, Symbol,
                         Sort, Reduction, count, Slice, Expr, nelements,
-                        Arithmetic, USub, Not, UnaryOp, BinOp)
+                        UnaryOp, BinOp)
 from blaze.compatibility import basestring, map
+from blaze.expr.optimize import simple_selections
 from ..dispatch import dispatch
 from .numexpr import broadcast_numexpr_collect, print_numexpr
 
@@ -158,9 +159,10 @@ WantToBroadcast = UnaryOp, BinOp
 @dispatch(Expr, tb.Table)
 def optimize(expr, seq):
     return broadcast_numexpr_collect(
-        expr,
+        simple_selections(expr),
         broadcastable=Broadcastable,
         want_to_broadcast=WantToBroadcast,
+        no_recurse=Selection,
     )
 
 

--- a/blaze/compute/python.py
+++ b/blaze/compute/python.py
@@ -324,6 +324,12 @@ def compute_up(t, seq, **kwargs):
     return filter(predicate, seq)
 
 
+@dispatch(Selection, Sequence, Sequence)
+def compute_up(expr, seq, predicate, **kwargs):
+    preds = iter(predicate)
+    return filter(lambda _: next(preds), seq)
+
+
 @dispatch(Reduction, Sequence)
 def compute_up(t, seq, **kwargs):
     if t.axis != (0,):

--- a/blaze/compute/spark.py
+++ b/blaze/compute/spark.py
@@ -3,11 +3,14 @@ from __future__ import absolute_import, division, print_function
 from toolz import compose, identity
 from datashape.predicates import isscalar
 
-from ..expr import (Expr, ElemWise, Selection, Sort, Apply, Distinct, Join,
-                    By, Label, Summary, by, ReLabel, Like, Reduction, Head)
+from ..expr import (
+    Expr, ElemWise, SimpleSelection, Sort, Apply, Distinct, Join, By, Label,
+    Summary, by, ReLabel, Like, Reduction, Head
+)
 from .python import (compute, rrowfunc, rowfunc, pair_assemble,
                      reduce_by_funcs, binops, like_regex_predicate)
 from ..expr.broadcast import broadcast_collect
+from ..expr.optimize import simple_selections
 from ..compatibility import builtins, unicode
 from ..expr import reductions
 from ..dispatch import dispatch
@@ -34,7 +37,7 @@ except:
 
 @dispatch(Expr, RDD)
 def optimize(expr, seq):
-    return broadcast_collect(expr)
+    return simple_selections(broadcast_collect(expr))
 
 
 @dispatch(ElemWise, RDD)
@@ -43,7 +46,7 @@ def compute_up(t, rdd, **kwargs):
     return rdd.map(func)
 
 
-@dispatch(Selection, RDD)
+@dispatch(SimpleSelection, RDD)
 def compute_up(t, rdd, **kwargs):
     predicate = optimize(t.predicate, rdd)
     predicate = rrowfunc(predicate, t._child)

--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -154,9 +154,24 @@ def compute_up(t, data, **kwargs):
         return t.op(t.lhs, column)
 
 
-@compute_up.register(BinOp, (ColumnElement, base), ColumnElement)
-@compute_up.register(BinOp, ColumnElement, base)
+@compute_up.register(
+    BinOp, (Select, ColumnElement, base), (Select, ColumnElement),
+)
+@compute_up.register(BinOp, (Select, ColumnElement), base)
 def binop_sql(t, lhs, rhs, **kwargs):
+    if isinstance(lhs, Select):
+        assert len(lhs.c) == 1, (
+            'Select cannot have more than a single column when doing'
+            ' arithmetic, got %s' % lhs
+        )
+        lhs = first(lhs.inner_columns)
+    if isinstance(rhs, Select):
+        assert len(rhs.c) == 1, (
+            'Select cannot have more than a single column when doing'
+            ' arithmetic, got %s' % rhs
+        )
+        rhs = first(rhs.inner_columns)
+
     return t.op(lhs, rhs)
 
 

--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -280,7 +280,7 @@ def compute_up(expr, data, scope=None, **kwargs):
     return compute_up(expr, data, predicate, scope=scope, **kwargs)
 
 
-@dispatch(Selection, sa.sql.ColumnElement, ClauseElement)
+@dispatch(Selection, sa.sql.ColumnElement, ColumnElement)
 def compute_up(expr, col, predicate, **kwargs):
     return sa.select([col]).where(predicate)
 
@@ -306,7 +306,7 @@ def compute_up(t, s, scope=None, **kwargs):
     return compute_up(t, s, _get_pred(t, s, scope), scope=scope, **kwargs)
 
 
-@dispatch(Selection, Selectable, ClauseElement)
+@dispatch(Selection, Selectable, ColumnElement)
 def compute_up(expr, tbl, predicate, scope=None, **kwargs):
     try:
         return tbl.where(predicate)

--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -285,25 +285,26 @@ def compute_up(expr, col, predicate, **kwargs):
     return sa.select([col]).where(predicate)
 
 
-def _get_pred(expr, tbl, scope):
-    return compute(
-        expr.predicate,
-        toolz.merge(
-            {
-                expr._child[col.name]: col
-                for col in getattr(tbl, 'inner_columns', tbl.columns)
-            },
-            scope,
-        ),
-        optimize=False,
-        post_compute=False,
-    )
-
-
-
 @dispatch(Selection, Selectable)
-def compute_up(t, s, scope=None, **kwargs):
-    return compute_up(t, s, _get_pred(t, s, scope), scope=scope, **kwargs)
+def compute_up(expr, sel, scope=None, **kwargs):
+    return compute_up(
+        expr,
+        sel,
+        compute(
+            expr.predicate,
+            toolz.merge(
+                {
+                    expr._child[col.name]: col
+                    for col in getattr(sel, 'inner_columns', sel.columns)
+                },
+                scope,
+            ),
+            optimize=False,
+            post_compute=False,
+        ),
+        scope=scope,
+        **kwargs
+    )
 
 
 @dispatch(Selection, Selectable, ColumnElement)

--- a/blaze/compute/tests/test_numpy_compute.py
+++ b/blaze/compute/tests/test_numpy_compute.py
@@ -631,3 +631,16 @@ def test_binary_math(funcname):
     expected = getattr(np, binary_name_map.get(funcname, funcname))(s_data,
                                                                     t_data)
     assert np.all(result == expected)
+
+
+def test_selection_inner_inputs():
+    s_data = np.arange(5).reshape(5, 1)
+    t_data = np.arange(5).reshape(5, 1)
+
+    s = symbol('s', 'var * {a: int64}')
+    t = symbol('t', 'var * {a: int64}')
+
+    assert (
+        compute(s[s.a == t.a], {s: s_data, t: t_data}) ==
+        s_data
+    ).all()

--- a/blaze/compute/tests/test_pandas_compute.py
+++ b/blaze/compute/tests/test_pandas_compute.py
@@ -819,6 +819,7 @@ def test_time_field():
     assert_series_equal(result, expected)
 
 
+
 @pytest.mark.parametrize('n', [-1, 0, 1])
 def test_shift(n):
     data = pd.Series(pd.date_range(start='20120101', end='20120102', freq='H'))
@@ -826,3 +827,16 @@ def test_shift(n):
     result = compute(s.shift(n), data)
     expected = data.shift(n)
     assert_series_equal(result, expected)
+
+
+def test_selection_inner_inputs():
+    s_data = pd.DataFrame({'a': np.arange(5)})
+    t_data = pd.DataFrame({'a': np.arange(5)})
+
+    s = symbol('s', 'var * {a: int64}')
+    t = symbol('t', 'var * {a: int64}')
+
+    tm.assert_frame_equal(
+        compute(s[s.a == t.a], {s: s_data, t: t_data}),
+        s_data
+    )

--- a/blaze/compute/tests/test_sql_compute.py
+++ b/blaze/compute/tests/test_sql_compute.py
@@ -334,17 +334,17 @@ def test_count_on_table():
     result = compute(t[t.amount > 0].count(), s)
     assert (
         normalize(str(result)) == normalize("""
-        SELECT count(accounts.id) as count_1
+        SELECT count(accounts.id) as t_count
         FROM accounts
         WHERE accounts.amount > :amount_1""")
 
         or
 
         normalize(str(result)) == normalize("""
-        SELECT count(alias.id) as count
+        SELECT count(alias.id) as t_count
         FROM (SELECT accounts.name AS name, accounts.amount AS amount, accounts.id AS id
               FROM accounts
-              WHERE accounts.amount > :amount_1) as alias"""))
+              WHERE accounts.amount > :amount_1) as alias_2"""))
 
 
 def test_distinct():

--- a/blaze/compute/tests/test_sql_compute.py
+++ b/blaze/compute/tests/test_sql_compute.py
@@ -1898,3 +1898,11 @@ def test_tail_sort_in_chilren():
     )))
     result = normalize(str(compute(t.name.sort('id').tail(5), {t: s})))
     assert expected == result
+
+
+def test_selection_inner_inputs():
+    result = normalize(str(compute(t[t.id == tdate.id], {t: s, tdate: sdate})))
+    expected = normalize("""
+    select {a}.name, {a}.amount, {a}.id from {a}, {b} where {a}.id = {b}.id
+    """).format(a=s.name, b=sdate.name)
+    assert result == expected

--- a/blaze/expr/broadcast.py
+++ b/blaze/expr/broadcast.py
@@ -107,8 +107,10 @@ Broadcastable = (Map, Field, DateTime, UnaryOp, BinOp, Coerce, Shift)
 WantToBroadcast = (Map, DateTime, UnaryOp, BinOp, Coerce, Shift)
 
 
-def broadcast_collect(expr, Broadcastable=Broadcastable,
-                      WantToBroadcast=WantToBroadcast):
+def broadcast_collect(expr,
+                      broadcastable=Broadcastable,
+                      want_to_broadcast=WantToBroadcast,
+                      no_recurse=None):
     """ Collapse expression down using Broadcast - Tabular cases only
 
     Expressions of type Broadcastables are swallowed into Broadcast
@@ -125,15 +127,20 @@ def broadcast_collect(expr, Broadcastable=Broadcastable,
     >>> broadcast_collect(expr)
     Broadcast(_children=(t,), _scalars=(t,), _scalar_expr=t.x + (2 * (exp(-((t.x - 1.3) ** 2)))))
     """
-    if (isinstance(expr, WantToBroadcast) and
+    if (isinstance(expr, want_to_broadcast) and
             iscollection(expr.dshape)):
-        leaves = leaves_of_type(Broadcastable, expr)
+        leaves = leaves_of_type(broadcastable, expr)
         expr = broadcast(expr, sorted(leaves, key=str))
 
+    if no_recurse is not None and isinstance(expr, no_recurse):
+        return expr
+
     # Recurse down
-    children = [broadcast_collect(i, Broadcastable, WantToBroadcast)
-                for i in expr._inputs]
-    return expr._subs(dict(zip(expr._inputs, children)))
+    children = (
+        broadcast_collect(i, broadcastable, want_to_broadcast, no_recurse)
+        for i in expr._inputs
+    )
+    return expr._subs({e: c for e, c in zip(expr._inputs, children)})
 
 
 @curry

--- a/blaze/expr/expressions.py
+++ b/blaze/expr/expressions.py
@@ -19,10 +19,32 @@ from ..dispatch import dispatch
 from .utils import hashable_index, replace_slices
 
 
-__all__ = ['Expr', 'ElemWise', 'Field', 'Symbol', 'discover', 'Projection',
-           'projection', 'Selection', 'selection', 'Label', 'label', 'Map',
-           'ReLabel', 'relabel', 'Apply', 'apply', 'Slice', 'shape', 'ndim',
-           'label', 'symbol', 'Coerce', 'coerce']
+__all__ = [
+    'Apply',
+    'Coerce',
+    'ElemWise',
+    'Expr',
+    'Field',
+    'Label',
+    'Map',
+    'Projection',
+    'ReLabel',
+    'Selection',
+    'SimpleSelection',
+    'Slice',
+    'Symbol',
+    'apply',
+    'coerce',
+    'discover',
+    'label',
+    'label',
+    'ndim',
+    'projection',
+    'relabel',
+    'selection',
+    'shape',
+    'symbol',
+]
 
 
 _attr_cache = dict()
@@ -473,6 +495,13 @@ class Selection(Expr):
         shape = list(self._child.dshape.shape)
         shape[0] = Var()
         return DataShape(*(shape + [self._child.dshape.measure]))
+
+
+class SimpleSelection(Selection):
+    """Internal selection class that does not treat the predicate as an input.
+    """
+    __slots__ = Selection.__slots__
+    __inputs__ = '_child',
 
 
 @copydoc(Selection)

--- a/blaze/expr/expressions.py
+++ b/blaze/expr/expressions.py
@@ -459,6 +459,7 @@ class Selection(Expr):
     >>> deadbeats = accounts[accounts.amount < 0]
     """
     __slots__ = '_hash', '_child', 'predicate'
+    __inputs__ = '_child', 'predicate'
 
     def __str__(self):
         return "%s[%s]" % (self._child, self.predicate)

--- a/blaze/expr/expressions.py
+++ b/blaze/expr/expressions.py
@@ -461,6 +461,10 @@ class Selection(Expr):
     __slots__ = '_hash', '_child', 'predicate'
     __inputs__ = '_child', 'predicate'
 
+    @property
+    def _name(self):
+        return self._child._name
+
     def __str__(self):
         return "%s[%s]" % (self._child, self.predicate)
 

--- a/blaze/expr/tests/test_broadcast.py
+++ b/blaze/expr/tests/test_broadcast.py
@@ -59,8 +59,11 @@ def test_optimize_broadcast():
     expr = (t.distinct().x + 1).distinct()
 
     expected = broadcast(t.distinct().x + 1, [t.distinct()]).distinct()
-    result = broadcast_collect(expr, Broadcastable=(Field, Arithmetic),
-                                     WantToBroadcast=(Field, Arithmetic))
+    result = broadcast_collect(
+        expr,
+        broadcastable=(Field, Arithmetic),
+        want_to_broadcast=(Field, Arithmetic),
+    )
 
     assert result.isidentical(expected)
 
@@ -76,8 +79,11 @@ def test_leaves_of_type():
 def test_broadcast_collect_doesnt_collect_scalars():
     expr = xx + yy * a
 
-    assert broadcast_collect(expr, Broadcastable=Arithmetic,
-                                   WantToBroadcast=Arithmetic).isidentical(expr)
+    assert broadcast_collect(
+        expr,
+        broadcastable=Arithmetic,
+        want_to_broadcast=Arithmetic,
+    ).isidentical(expr)
 
 
 def test_table_broadcast():

--- a/docs/source/whatsnew/0.9.0.txt
+++ b/docs/source/whatsnew/0.9.0.txt
@@ -59,3 +59,7 @@ Bug Fixes
   (:issue:`1288`).
 * Fixed a bug where comparisons to a empty string magically converted
   the empty string to ``None`` (:issue:`1308`).
+* Fixed a bug where leaves that only appeared in the predicate of a selection
+  would not be in scope in time to compute the predicate. This would cause whole
+  expressions like ``a[a > b]`` to fail because ``b`` was not in scope
+  (:issue:`1275`).


### PR DESCRIPTION
Things like `a[a.a == b.a]` would fail because it wouldn't compute the `b.a.`