### PR TITLE
Optional relationals

### DIFF
--- a/blaze/expr/arithmetic.py
+++ b/blaze/expr/arithmetic.py
@@ -4,7 +4,7 @@ import operator
 from toolz import first
 import numpy as np
 import pandas as pd
-from datashape import dshape, var, DataShape
+from datashape import dshape, var, DataShape, Option
 from dateutil.parser import parse as dt_parse
 from datashape.predicates import isscalar, isboolean, isnumeric, isdatelike
 from datashape import coretypes as ct, discover, unsigned, promote, optionify
@@ -323,7 +323,14 @@ interp = _mkbin('interp', Interp, reflected=False, private=False)
 
 
 class Relational(Arithmetic):
-    _dtype = ct.bool_
+    @property
+    def _dtype(self):
+        # we can't simply use .schema or .datashape because we may have a bare
+        # integer, for example
+        lhs, rhs = discover(self.lhs).measure, discover(self.rhs).measure
+        if isinstance(lhs, Option) or isinstance(rhs, Option):
+            return Option(ct.bool_)
+        return ct.bool_
 
 
 class Eq(Relational):

--- a/blaze/expr/arithmetic.py
+++ b/blaze/expr/arithmetic.py
@@ -322,7 +322,7 @@ _sub, _rsub = _mkbin('sub', Sub)
 interp = _mkbin('interp', Interp, reflected=False, private=False)
 
 
-class Relational(Arithmetic):
+class _Optional(Arithmetic):
     @property
     def _dtype(self):
         # we can't simply use .schema or .datashape because we may have a bare
@@ -331,6 +331,11 @@ class Relational(Arithmetic):
         if isinstance(lhs, Option) or isinstance(rhs, Option):
             return Option(ct.bool_)
         return ct.bool_
+
+
+class Relational(_Optional):
+    # Leave this to separate relationals from other types of optionals.
+    pass
 
 
 class Eq(Relational):
@@ -363,22 +368,22 @@ class Lt(Relational):
     op = operator.lt
 
 
-class And(Arithmetic):
+class And(_Optional):
     symbol = '&'
     op = operator.and_
-    _dtype = ct.bool_
 
 
-class Or(Arithmetic):
+class Or(_Optional):
     symbol = '|'
     op = operator.or_
-    _dtype = ct.bool_
 
 
 class Not(UnaryOp):
     symbol = '~'
     op = operator.invert
-    _dtype = ct.bool_
+
+    def _dtype(self):
+        return self._child.dshape
 
     def __str__(self):
         return '~%s' % parenthesize(eval_str(self._child))

--- a/blaze/expr/arithmetic.py
+++ b/blaze/expr/arithmetic.py
@@ -382,8 +382,9 @@ class Not(UnaryOp):
     symbol = '~'
     op = operator.invert
 
+    @property
     def _dtype(self):
-        return self._child.dshape
+        return self._child.schema
 
     def __str__(self):
         return '~%s' % parenthesize(eval_str(self._child))

--- a/docs/source/whatsnew/0.9.0.txt
+++ b/docs/source/whatsnew/0.9.0.txt
@@ -48,3 +48,5 @@ Bug Fixes
   have CTEs (:issue:`1278`).
 * Fixed a bug where we couldn't display an empty string identifier
   in interactive mode (:issue:`1279`).
+* Fixed a bug where comparisons with optionals that should have resulted in
+  optionals did not (:issue:`1292`).


### PR DESCRIPTION
Modify Arithmetic classes so that operations with optionals result in an optional type and add associated tests.