### PR TITLE
DOC: Use copydoc for `symbol`.

### DIFF
--- a/blaze/expr/expressions.py
+++ b/blaze/expr/expressions.py
@@ -236,11 +236,6 @@ def _symbol_key(args, kwargs):
     return (name, ds, token)
 
 
-@memoize(cache=_symbol_cache, key=_symbol_key)
-def symbol(name, dshape, token=None):
-    return Symbol(name, dshape, token=token)
-
-
 class Symbol(Expr):
     """
     Symbolic data.  The leaf of a Blaze expression
@@ -270,6 +265,12 @@ class Symbol(Expr):
 
     def _resources(self):
         return dict()
+
+
+@memoize(cache=_symbol_cache, key=_symbol_key)
+@copydoc(Symbol)
+def symbol(name, dshape, token=None):
+    return Symbol(name, dshape, token=token)
 
 
 @dispatch(Symbol, dict)


### PR DESCRIPTION
Using `symbol` is harder than it should be right now for a couple reasons:

1. There's no docstring.
2. The function signature is trampled by `toolz.memoize`, so it just appears in IPython or `help()` as `*args, **kwargs`.
3. If you fail to pass a dshape to `symbol`, you get a cryptic error that looks like this:
```
In [1]: from blaze import symbol

In [2]: symbol('s')
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-9c4453b6cb13> in <module>()
----> 1 symbol('s')

/home/ssanderson/quantopian/toolz/toolz/functoolz.py in memof(*args, **kwargs)
    346             in_cache = k in cache
    347         except TypeError:
--> 348             raise TypeError("Arguments to memoized function must be hashable")
    349
    350         if in_cache:

TypeError: Arguments to memoized function must be hashable
```
The root cause here is that the cache key used by `symbol` tries to call `dshape(None)`, which raises a TypeError, which then gets swallowed by `memoize`, which assumes that the input argument wasn't hashable.

This PR fixes the first issue.  The other issues are probably best fixed upstream in toolz.

cc @llllllllll .