### PR TITLE
Pandas: sort(columns=) is deprecated, use sort_values(by=)

### DIFF
--- a/blaze/compatibility.py
+++ b/blaze/compatibility.py
@@ -2,11 +2,8 @@ from __future__ import absolute_import, division, print_function
 
 import sys
 from types import MethodType
-from distutils.version import LooseVersion
 
 import pandas.util.testing as tm
-
-import pandas as pd
 
 PY3 = sys.version_info[0] == 3
 PY2 = sys.version_info[0] == 2
@@ -136,17 +133,3 @@ def assert_series_equal(left, right, check_names=True, **kwargs):
         if check_names:
             assert left.name == right.name
         return tm.assert_series_equal(left, right, **kwargs)
-
-
-def _pandas_sort_old(df, *args, **kwargs):
-    """Use pd.sort() for older versions"""
-    return df.sort(*args, **kwargs)
-
-def _pandas_sort_new(df, *args, **kwargs):
-    """Use pd.sort_values() for newer versions"""
-    return df.sort_values(*args, **kwargs)
-
-if LooseVersion(pd.__version__) < '0.17.0':
-    pandas_sort = _pandas_sort_old
-else:
-    pandas_sort = _pandas_sort_new

--- a/blaze/compatibility.py
+++ b/blaze/compatibility.py
@@ -2,8 +2,11 @@ from __future__ import absolute_import, division, print_function
 
 import sys
 from types import MethodType
+from distutils.version import LooseVersion
 
 import pandas.util.testing as tm
+
+import pandas as pd
 
 PY3 = sys.version_info[0] == 3
 PY2 = sys.version_info[0] == 2
@@ -133,3 +136,17 @@ def assert_series_equal(left, right, check_names=True, **kwargs):
         if check_names:
             assert left.name == right.name
         return tm.assert_series_equal(left, right, **kwargs)
+
+
+def _pandas_sort_old(df, *args, **kwargs):
+    """Use pd.sort() for older versions"""
+    return df.sort(*args, **kwargs)
+
+def _pandas_sort_new(df, *args, **kwargs):
+    """Use pd.sort_values() for newer versions"""
+    return df.sort_values(*args, **kwargs)
+
+if LooseVersion(pd.__version__) < '0.17.0':
+    pandas_sort = _pandas_sort_old
+else:
+    pandas_sort = _pandas_sort_new

--- a/blaze/compute/pandas.py
+++ b/blaze/compute/pandas.py
@@ -51,7 +51,7 @@ from ..expr import (Projection, Field, Sort, Head, Tail, Broadcast, Selection,
 from ..expr import UnaryOp, BinOp, Interp
 from ..expr import symbol, common_subexpression
 
-from ..compatibility import _inttypes
+from ..compatibility import _inttypes, pandas_sort
 
 __all__ = []
 
@@ -457,7 +457,7 @@ def concat_nodup(a, b):
 
 @dispatch(Sort, DataFrame)
 def compute_up(t, df, **kwargs):
-    return df.sort_values(by=t.key, ascending=t.ascending)
+    return pandas_sort(df, t.key, ascending=t.ascending)
 
 
 @dispatch(Sort, Series)

--- a/blaze/compute/pandas.py
+++ b/blaze/compute/pandas.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import, division, print_function
 
 import fnmatch
 import itertools
+from distutils.version import LooseVersion
 
 import numpy as np
 
@@ -51,7 +52,7 @@ from ..expr import (Projection, Field, Sort, Head, Tail, Broadcast, Selection,
 from ..expr import UnaryOp, BinOp, Interp
 from ..expr import symbol, common_subexpression
 
-from ..compatibility import _inttypes, pandas_sort
+from ..compatibility import _inttypes
 
 __all__ = []
 
@@ -455,9 +456,15 @@ def concat_nodup(a, b):
             return pd.concat([a, b], axis=1)
 
 
+pdsort = getattr(
+    pd.DataFrame,
+    'sort' if LooseVersion(pd.__version__) < '0.17.0' else 'sort_values'
+)
+
+
 @dispatch(Sort, DataFrame)
 def compute_up(t, df, **kwargs):
-    return pandas_sort(df, t.key, ascending=t.ascending)
+    return pdsort(df, t.key, ascending=t.ascending)
 
 
 @dispatch(Sort, Series)

--- a/blaze/compute/pandas.py
+++ b/blaze/compute/pandas.py
@@ -457,7 +457,7 @@ def concat_nodup(a, b):
 
 @dispatch(Sort, DataFrame)
 def compute_up(t, df, **kwargs):
-    return df.sort(t.key, ascending=t.ascending)
+    return df.sort_values(by=t.key, ascending=t.ascending)
 
 
 @dispatch(Sort, Series)

--- a/blaze/compute/tests/test_pandas_compute.py
+++ b/blaze/compute/tests/test_pandas_compute.py
@@ -17,7 +17,8 @@ from blaze import dshape, discover, transform
 from blaze.expr import symbol, join, by, summary, distinct, shape
 from blaze.expr import (merge, exp, mean, count, nunique, sum, min, max, any,
                         var, std, concat)
-from blaze.compatibility import builtins, xfail, assert_series_equal
+from blaze.compatibility import (builtins, xfail, assert_series_equal,
+                                 pandas_sort)
 
 
 t = symbol('t', 'var * {name: string, amount: int, id: int}')
@@ -329,13 +330,13 @@ def test_join_promotion():
 
 def test_sort():
     tm.assert_frame_equal(compute(t.sort('amount'), df),
-                          df.sort_values(by='amount'))
+                          pandas_sort(df, 'amount'))
 
     tm.assert_frame_equal(compute(t.sort('amount', ascending=True), df),
-                          df.sort_values(by='amount', ascending=True))
+                          pandas_sort(df, 'amount', ascending=True))
 
     tm.assert_frame_equal(compute(t.sort(['amount', 'id']), df),
-                          df.sort_values(by=['amount', 'id']))
+                          pandas_sort(df, ['amount', 'id']))
 
 
 def test_sort_on_series_no_warning(recwarn):
@@ -484,8 +485,8 @@ def test_outer_join():
                           (4., 'Dennis', 400., 'Moscow')],
                          columns=['id', 'name', 'amount', 'city'])
 
-    result = df.sort_values(by='id').to_records(index=False)
-    expected = expected.sort_values(by='id').to_records(index=False)
+    result = pandas_sort(df, 'id').to_records(index=False)
+    expected = pandas_sort(expected, 'id').to_records(index=False)
     np.array_equal(result, expected)
 
     df = compute(join(lsym, rsym, how='outer'), {lsym: left, rsym: right})
@@ -496,8 +497,8 @@ def test_outer_join():
                           (4., 'Dennis', 400., 'Moscow')],
                          columns=['id', 'name', 'amount', 'city'])
 
-    result = df.sort_values(by='id').to_records(index=False)
-    expected = expected.sort_values(by='id').to_records(index=False)
+    result = pandas_sort(df, 'id').to_records(index=False)
+    expected = pandas_sort(expected, 'id').to_records(index=False)
     np.array_equal(result, expected)
 
 

--- a/blaze/compute/tests/test_pandas_compute.py
+++ b/blaze/compute/tests/test_pandas_compute.py
@@ -13,12 +13,12 @@ from pandas import DataFrame, Series
 from string import ascii_lowercase
 
 from blaze.compute.core import compute
+from blaze.compute.pandas import pdsort
 from blaze import dshape, discover, transform
 from blaze.expr import symbol, join, by, summary, distinct, shape
 from blaze.expr import (merge, exp, mean, count, nunique, sum, min, max, any,
                         var, std, concat)
-from blaze.compatibility import (builtins, xfail, assert_series_equal,
-                                 pandas_sort)
+from blaze.compatibility import builtins, xfail, assert_series_equal
 
 
 t = symbol('t', 'var * {name: string, amount: int, id: int}')
@@ -330,13 +330,13 @@ def test_join_promotion():
 
 def test_sort():
     tm.assert_frame_equal(compute(t.sort('amount'), df),
-                          pandas_sort(df, 'amount'))
+                          pdsort(df, 'amount'))
 
     tm.assert_frame_equal(compute(t.sort('amount', ascending=True), df),
-                          pandas_sort(df, 'amount', ascending=True))
+                          pdsort(df, 'amount', ascending=True))
 
     tm.assert_frame_equal(compute(t.sort(['amount', 'id']), df),
-                          pandas_sort(df, ['amount', 'id']))
+                          pdsort(df, ['amount', 'id']))
 
 
 def test_sort_on_series_no_warning(recwarn):
@@ -485,8 +485,8 @@ def test_outer_join():
                           (4., 'Dennis', 400., 'Moscow')],
                          columns=['id', 'name', 'amount', 'city'])
 
-    result = pandas_sort(df, 'id').to_records(index=False)
-    expected = pandas_sort(expected, 'id').to_records(index=False)
+    result = pdsort(df, 'id').to_records(index=False)
+    expected = pdsort(expected, 'id').to_records(index=False)
     np.array_equal(result, expected)
 
     df = compute(join(lsym, rsym, how='outer'), {lsym: left, rsym: right})
@@ -497,8 +497,8 @@ def test_outer_join():
                           (4., 'Dennis', 400., 'Moscow')],
                          columns=['id', 'name', 'amount', 'city'])
 
-    result = pandas_sort(df, 'id').to_records(index=False)
-    expected = pandas_sort(expected, 'id').to_records(index=False)
+    result = pdsort(df, 'id').to_records(index=False)
+    expected = pdsort(expected, 'id').to_records(index=False)
     np.array_equal(result, expected)
 
 

--- a/blaze/compute/tests/test_pandas_compute.py
+++ b/blaze/compute/tests/test_pandas_compute.py
@@ -329,13 +329,13 @@ def test_join_promotion():
 
 def test_sort():
     tm.assert_frame_equal(compute(t.sort('amount'), df),
-                          df.sort('amount'))
+                          df.sort_values(by='amount'))
 
     tm.assert_frame_equal(compute(t.sort('amount', ascending=True), df),
-                          df.sort('amount', ascending=True))
+                          df.sort_values(by='amount', ascending=True))
 
     tm.assert_frame_equal(compute(t.sort(['amount', 'id']), df),
-                          df.sort(['amount', 'id']))
+                          df.sort_values(by=['amount', 'id']))
 
 
 def test_sort_on_series_no_warning(recwarn):
@@ -484,8 +484,8 @@ def test_outer_join():
                           (4., 'Dennis', 400., 'Moscow')],
                          columns=['id', 'name', 'amount', 'city'])
 
-    result = df.sort('id').to_records(index=False)
-    expected = expected.sort('id').to_records(index=False)
+    result = df.sort_values(by='id').to_records(index=False)
+    expected = expected.sort_values(by='id').to_records(index=False)
     np.array_equal(result, expected)
 
     df = compute(join(lsym, rsym, how='outer'), {lsym: left, rsym: right})
@@ -496,8 +496,8 @@ def test_outer_join():
                           (4., 'Dennis', 400., 'Moscow')],
                          columns=['id', 'name', 'amount', 'city'])
 
-    result = df.sort('id').to_records(index=False)
-    expected = expected.sort('id').to_records(index=False)
+    result = df.sort_values(by='id').to_records(index=False)
+    expected = expected.sort_values(by='id').to_records(index=False)
     np.array_equal(result, expected)
 
 


### PR DESCRIPTION
`Pandas 0.17.0` gives a warning for the use of `sort`

```FutureWarning: sort(columns=....) is deprecated, use sort_values(by=.....)```

Probably move to sort_values, as suggested?