### PR TITLE
kill the attr cache

### DIFF
--- a/blaze/expr/expressions.py
+++ b/blaze/expr/expressions.py
@@ -48,9 +48,6 @@ __all__ = [
 ]
 
 
-_attr_cache = dict()
-
-
 def isvalid_identifier(s):
     """Check whether a string is a valid Python identifier
 
@@ -104,8 +101,7 @@ class Expr(Node):
     contains shared logic and syntax.  It in turn inherits from ``Node`` which
     holds all tree traversal logic
     """
-
-    __slots__ = '_hash', '__weakref__'
+    __slots__ = '_hash', '__weakref__', '__dict__'
 
     def _get_field(self, fieldname):
         if not isinstance(self.dshape.measure, Record):
@@ -200,10 +196,6 @@ class Expr(Node):
         assert key != '_hash', \
             '%s should set _hash in __init__' % type(self).__name__
         try:
-            return _attr_cache[(self, key)]
-        except:
-            pass
-        try:
             result = object.__getattribute__(self, key)
         except AttributeError:
             fields = dict(zip(map(valid_identifier, self.fields),
@@ -227,7 +219,9 @@ class Expr(Node):
                     result = self[fields[key]]
             else:
                 raise
-        _attr_cache[(self, key)] = result
+
+        # cache the attribute lookup, getattr will not be invoked again.
+        setattr(self, key, result)
         return result
 
     @property

--- a/blaze/expr/tests/test_expr.py
+++ b/blaze/expr/tests/test_expr.py
@@ -12,7 +12,7 @@ from blaze.expr import symbol, label, Field, Expr, Node
 
 
 def test_slots():
-    assert Expr.__slots__ == ('_hash', '__weakref__')
+    assert Expr.__slots__ == ('_hash', '__weakref__', '__dict__')
     assert Node.__slots__ == ()
 
 
@@ -148,10 +148,6 @@ def test_hash_to_different_values():
     expr2 = s >= '20121001'
     assert expr2 & expr is not None
     assert hash(expr) == hash(expr2)
-
-    from blaze.expr.expressions import _attr_cache
-    assert (expr, '_and') in _attr_cache
-    assert (expr2, '_and') in _attr_cache
 
 
 @pytest.mark.parametrize('dshape', [var * float32,

--- a/docs/source/whatsnew/0.9.0.txt
+++ b/docs/source/whatsnew/0.9.0.txt
@@ -74,6 +74,8 @@ Bug Fixes
 * Fixed pickling of blaze expressions with interactive symbols (:issue:`1319`).
 * Fixed repring partials in blaze expression to show keyword arguments
   (:issue:`1319`).
+* Fixed a memory leak that would preserve the lifetime of any blaze expression
+  that had cached an attribute access (:issue:`1335`).
 
 Miscellaneous
 ~~~~~~~~~~~~~


### PR DESCRIPTION
The attr cache held a reference to every blaze expression that ever had
an attribute looked up on it. This cache prevented them from ever
getting garbage collected.

Moving the attr_cache to the objects' `__dict__` slot allows for the
object to become isolated and the cycle detector can kill the object.