### PR TITLE
ENH: allow clients to send extra compute and odo kwargs

### DIFF
--- a/blaze/compute/core.py
+++ b/blaze/compute/core.py
@@ -202,6 +202,7 @@ _names = ('leaf_%d' % i for i in itertools.count(1))
 _leaf_cache = dict()
 _used_tokens = set()
 
+
 def _reset_leaves():
     _leaf_cache.clear()
     _used_tokens.clear()

--- a/blaze/interactive.py
+++ b/blaze/interactive.py
@@ -232,7 +232,7 @@ def coerce_to(typ, x, odo_kwargs=None):
     try:
         return typ(x)
     except TypeError:
-        return odo(x, typ, **odo_kwargs or {})
+        return odo(x, typ, **(odo_kwargs or {}))
 
 
 def coerce_scalar(result, dshape, odo_kwargs=None):

--- a/blaze/interactive.py
+++ b/blaze/interactive.py
@@ -1,10 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
 from collections import Iterator
-from functools import reduce
-
 import decimal
 import datetime
+from functools import reduce, partial
 import itertools
 import operator
 import warnings
@@ -229,26 +228,27 @@ def short_dshape(ds, nlines=5):
     return s
 
 
-def coerce_to(typ, x):
+def coerce_to(typ, x, odo_kwargs=None):
     try:
         return typ(x)
     except TypeError:
-        return odo(x, typ)
+        return odo(x, typ, **odo_kwargs or {})
 
 
-def coerce_scalar(result, dshape):
+def coerce_scalar(result, dshape, odo_kwargs=None):
+    coerce_ = partial(coerce_to, x=result, odo_kwargs=odo_kwargs)
     if 'float' in dshape:
-        return coerce_to(float, result)
+        return coerce_(float)
     if 'decimal' in dshape:
-        return coerce_to(decimal.Decimal, result)
+        return coerce_(decimal.Decimal)
     elif 'int' in dshape:
-        return coerce_to(int, result)
+        return coerce_(int)
     elif 'bool' in dshape:
-        return coerce_to(bool, result)
+        return coerce_(bool)
     elif 'datetime' in dshape:
-        return coerce_to(Timestamp, result)
+        return coerce_(Timestamp)
     elif 'date' in dshape:
-        return coerce_to(datetime.date, result)
+        return coerce_(datetime.date)
     else:
         return result
 

--- a/blaze/server/client.py
+++ b/blaze/server/client.py
@@ -143,7 +143,7 @@ def mimetype(serial):
 
 
 @dispatch(Expr, Client)
-def compute_down(expr, ec, **kwargs):
+def compute_down(expr, ec, compute_kwargs=None, odo_kwargs=None, **kwargs):
     from .server import to_tree
     tree = to_tree(expr)
 
@@ -151,7 +151,11 @@ def compute_down(expr, ec, **kwargs):
     r = post(
         ec,
         '/compute',
-        data=serial.dumps({'expr': tree}),
+        data=serial.dumps({
+            'expr': tree,
+            'compute_kwargs': compute_kwargs,
+            'odo_kwargs': odo_kwargs,
+        }),
         auth=ec.auth,
         headers=mimetype(serial),
     )

--- a/blaze/server/server.py
+++ b/blaze/server/server.py
@@ -404,6 +404,8 @@ mimetype_regex = re.compile(r'^application/vnd\.blaze\+(%s)$' %
 @check_request
 def compserver(payload, serial):
     ns = payload.get('namespace', dict())
+    compute_kwargs = payload.get('compute_kwargs') or {}
+    odo_kwargs = payload.get('odo_kwargs') or {}
     dataset = _get_data()
     ns[':leaf'] = symbol('leaf', discover(dataset))
 
@@ -412,10 +414,10 @@ def compserver(payload, serial):
     leaf = expr._leaves()[0]
 
     try:
-        result = compute(expr, {leaf: dataset})
+        result = compute(expr, {leaf: dataset}, **compute_kwargs)
 
         if iscollection(expr.dshape):
-            result = odo(result, list)
+            result = odo(result, list, **odo_kwargs)
         elif isscalar(expr.dshape):
             result = coerce_scalar(result, str(expr.dshape))
     except NotImplementedError as e:

--- a/blaze/server/server.py
+++ b/blaze/server/server.py
@@ -425,7 +425,10 @@ def compserver(payload, serial):
         return ("Computation not supported:\n%s" % e, 501)
     except Exception as e:
         # 500: Internal Server Error
-        return ("Computation failed with message:\n%s" % e, 500)
+        return (
+            "Computation failed with message:\n%s: %s" % (type(e).__name__, e),
+            500,
+        )
 
     return serial.dumps({
         'datashape': str(expr.dshape),

--- a/blaze/server/tests/test_server.py
+++ b/blaze/server/tests/test_server.py
@@ -8,12 +8,16 @@ from contextlib import contextmanager
 from copy import copy
 
 import datashape
+from datashape.util.testing import assert_dshape_equal
 import numpy as np
+from odo import odo, convert
 from datetime import datetime
 from pandas import DataFrame
+from pandas.util.testing import assert_frame_equal
 from toolz import pipe
 
-from odo import odo
+from blaze.dispatch import dispatch
+from blaze.expr import Expr
 from blaze.utils import example
 from blaze import (discover, symbol, by, CSV, compute, join, into, resource,
                    Data)
@@ -34,10 +38,43 @@ events = DataFrame([[1, datetime(2000, 1, 1, 12, 0, 0)],
 
 db = resource('sqlite:///' + example('iris.db'))
 
-data = {'accounts': accounts,
-          'cities': cities,
-          'events': events,
-              'db': db}
+
+class DumbResource(object):
+    df = DataFrame({
+        'a': np.arange(5),
+        'b': np.arange(5, 10),
+    })
+
+    class NoResource(Exception):
+        pass
+
+
+@convert.register(DataFrame, DumbResource)
+def dumb_to_df(d, return_df=None, **kwargs):
+    if return_df is None:
+        raise DumbResource.NoResource('return_df must be passed')
+    to_return = odo(return_df, DataFrame, dshape=discover(d))
+    assert_frame_equal(to_return, DumbResource.df)
+    return to_return
+
+
+@dispatch(Expr, DumbResource)
+def compute_down(expr, d, **kwargs):
+    return dumb_to_df(d, **kwargs)
+
+
+@discover.register(DumbResource)
+def _discover_dumb(d):
+    return discover(DumbResource.df)
+
+
+data = {
+    'accounts': accounts,
+    'cities': cities,
+    'events': events,
+    'db': db,
+    'dumb': DumbResource(),
+}
 
 
 @pytest.fixture(scope='module')
@@ -621,3 +658,78 @@ def test_bad_add_payload(empty_server, serial):
         data=blob,
     )
     assert response1.status_code == 422
+
+
+@pytest.mark.parametrize('serial', all_formats)
+def test_odo_kwargs(test, serial):
+    expr = t.dumb
+    bad_query = {'expr': to_tree(expr)}
+
+    result = test.post(
+        '/compute',
+        headers=mimetype(serial),
+        data=serial.dumps(bad_query),
+    )
+    assert result.status_code == 500
+    assert b'return_df must be passed' in result.data
+
+    good_query = {
+        'expr': to_tree(expr),
+        'odo_kwargs': {
+            'return_df': odo(DumbResource.df, list),
+        },
+    }
+    result = test.post(
+        '/compute',
+        headers=mimetype(serial),
+        data=serial.dumps(good_query)
+    )
+    assert result.status_code == 200
+    data = serial.loads(result.data)
+    dshape = discover(DumbResource.df)
+    assert_dshape_equal(
+        datashape.dshape(data['datashape']),
+        dshape,
+    )
+    assert_frame_equal(
+        odo(data['data'], DataFrame, dshape=dshape),
+        DumbResource.df,
+    )
+
+
+@pytest.mark.parametrize('serial', all_formats)
+def test_compute_kwargs(test, serial):
+    expr = t.dumb.sort()
+    bad_query = {'expr': to_tree(expr)}
+
+    result = test.post(
+        '/compute',
+        headers=mimetype(serial),
+        data=serial.dumps(bad_query),
+    )
+    assert result.status_code == 500
+    assert b'return_df must be passed' in result.data
+
+    good_query = {
+        'expr': to_tree(expr),
+        'compute_kwargs': {
+            'return_df': odo(DumbResource.df, list),
+        },
+    }
+    result = test.post(
+        '/compute',
+        headers=mimetype(serial),
+        data=serial.dumps(good_query)
+    )
+    assert result.status_code == 200
+    data = serial.loads(result.data)
+    dshape = discover(DumbResource.df)
+    assert_dshape_equal(
+        datashape.dshape(data['datashape']),
+        dshape,
+    )
+    assert_frame_equal(
+        odo(data['data'], DataFrame, dshape=dshape),
+        DumbResource.df,
+    )
+>>>>>>> ENH: allow clients to send extra compute and odo kwargs

--- a/blaze/server/tests/test_server.py
+++ b/blaze/server/tests/test_server.py
@@ -732,4 +732,3 @@ def test_compute_kwargs(test, serial):
         odo(data['data'], DataFrame, dshape=dshape),
         DumbResource.df,
     )
->>>>>>> ENH: allow clients to send extra compute and odo kwargs

--- a/docs/source/whatsnew/0.9.0.txt
+++ b/docs/source/whatsnew/0.9.0.txt
@@ -26,6 +26,16 @@ Improved Backends
 * Adds support for :func:`~blaze.expr.collections.tail` in the sql backend
   (:issue:`1289`).
 * Blaze Server now supports dynamically adding datasets (:issue:`1329`).
+* Two new keyword only arguments are added to :func:`~blaze.compute` for use
+  when computing against a :class:`~blaze.Client` object:
+
+  1. ``compute_kwargs``: This is a dictionary to send to the server to use as
+     keyword arguments when calling ``compute`` on the server.
+  2. ``odo_kwargs``: This is a dictionary to send to the server to use aas
+     keyword arguments when calling ``odo`` on the server.
+
+  This extra information is completely optional and will have different meanings
+  based on the backend of the data on the server (:issue:`1342`).
 
 Experimental Features
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/whatsnew/0.9.0.txt
+++ b/docs/source/whatsnew/0.9.0.txt
@@ -31,7 +31,7 @@ Improved Backends
 
   1. ``compute_kwargs``: This is a dictionary to send to the server to use as
      keyword arguments when calling ``compute`` on the server.
-  2. ``odo_kwargs``: This is a dictionary to send to the server to use aas
+  2. ``odo_kwargs``: This is a dictionary to send to the server to use as
      keyword arguments when calling ``odo`` on the server.
 
   This extra information is completely optional and will have different meanings


### PR DESCRIPTION
`blaze.compute` accepts keyword args that can change how computations are
performed. This change forwards two extra dictionaries to the server for
use in computation and odo conversion. These are:

`compute_kwargs` - `**`unpacked into the compute call on the server
`odo_kwargs` - `**`unpacked into the odo call on the server