### PR TITLE
Fix repr of pseudo table things and fully deprecate the columns kwarg in Data

### DIFF
--- a/blaze/interactive.py
+++ b/blaze/interactive.py
@@ -97,20 +97,16 @@ class InteractiveSymbol(Symbol):
 
 
 @copydoc(InteractiveSymbol)
-def Data(data, dshape=None, name=None, fields=None, columns=None, schema=None,
-         **kwargs):
-    if columns:
-        raise ValueError("columns argument deprecated, use fields instead")
+def Data(data, dshape=None, name=None, fields=None, schema=None, **kwargs):
     if schema and dshape:
         raise ValueError("Please specify one of schema= or dshape= keyword"
                          " arguments")
 
     if isinstance(data, InteractiveSymbol):
-        return Data(data.data, dshape, name, fields, columns, schema, **kwargs)
+        return Data(data.data, dshape, name, fields, schema, **kwargs)
 
     if isinstance(data, _strtypes):
-        data = resource(data, schema=schema, dshape=dshape, columns=columns,
-                        **kwargs)
+        data = resource(data, schema=schema, dshape=dshape, **kwargs)
     if (isinstance(data, Iterator) and
             not isinstance(data, tuple(not_an_iterator))):
         data = tuple(data)

--- a/blaze/tests/test_interactive.py
+++ b/blaze/tests/test_interactive.py
@@ -394,11 +394,6 @@ def test_asarray_fails_on_different_column_names():
         Data(df, fields=list('abc'))
 
 
-def test_data_does_not_accept_columns_kwarg():
-    with pytest.raises(ValueError):
-        Data([(1, 2), (3, 4)], columns=list('ab'))
-
-
 def test_functions_as_bound_methods():
     """
     Test that all functions on an InteractiveSymbol are instance methods
@@ -459,3 +454,8 @@ def test_pickle_roundtrip():
     es = Data(np.array([1, 2, 3]))
     assert es.isidentical(pickle.loads(pickle.dumps(es)))
     assert (es + 1).isidentical(pickle.loads(pickle.dumps(es + 1)))
+
+
+@pytest.mark.xfail(raises=ValueError)
+def test_nameless_data():
+    repr(Data([('a', 1)]))

--- a/blaze/tests/test_interactive.py
+++ b/blaze/tests/test_interactive.py
@@ -456,6 +456,6 @@ def test_pickle_roundtrip():
     assert (es + 1).isidentical(pickle.loads(pickle.dumps(es + 1)))
 
 
-@pytest.mark.xfail(raises=ValueError)
 def test_nameless_data():
-    repr(Data([('a', 1)]))
+    data = [('a', 1)]
+    assert repr(data) in repr(Data(data))


### PR DESCRIPTION
closes #1252 

we now repr this correctly as:

```python
In [1]: from blaze import Data

In [2]: d = Data([('a', 1)])

In [3]: d
Out[3]:
Data:       [('a', 1)]
DataShape:  1 * (string, int64)
```