### PR TITLE
Fix issue with "by" expression and "count" reduction.

### DIFF
--- a/blaze/compute/pandas.py
+++ b/blaze/compute/pandas.py
@@ -386,7 +386,7 @@ def compute_by(t, s, g, df):
         )
     )
 
-    if len(list(is_field[False])) > 0:
+    if list(is_field[False]):
         emptys = DataFrame([0] * len(df.index),
                            index=df.index,
                            columns=[name for name, _ in is_field[False]])

--- a/blaze/compute/tests/test_pandas_compute.py
+++ b/blaze/compute/tests/test_pandas_compute.py
@@ -871,3 +871,8 @@ def test_selection_inner_inputs():
         compute(s[s.a == t.a], {s: s_data, t: t_data}),
         s_data
     )
+
+
+def test_by_with_reduction_on_df():
+    expr = by(tbig.name, id_sum=tbig.id.sum(), count=tbig.count())
+    compute(expr, dfbig)


### PR DESCRIPTION
This fixes an issue with the `by` expression and pandas.

The pandas `compute_by` takes some columns to group on `g`, a summary of reductions for after the groupby `s`, and data `df`.

To execute the `by`, first blaze constructs another dataframe with additional columns that will be reduced with the summary reductions. For example if one reduction is `df.a.sum` the column `df.a` is concated to `df`.  But if one of the reductions is `df.count`, what column do we add? Before we tried adding the whole dataframe which failed. This PR adds a column of zero values to fix the issue.

The below test failed before.
```python
tbig = symbol('tbig',
              'var * {name: string, sex: string[1], amount: int, id: int}')

dfbig = DataFrame([['Alice', 'F', 100, 1],
                   ['Alice', 'F', 100, 3],
                   ['Drew', 'F', 100, 4],
                   ['Drew', 'M', 100, 5],
                   ['Drew', 'M', 200, 5]],
                  columns=['name', 'sex', 'amount', 'id'])

def test_by_with_reduction_on_df():
    expr = by(tbig.name, id_sum=tbig.id.sum(), count=tbig.count())
    compute(expr, dfbig)
```