### PR TITLE
Support http resources and URLs of CSVs.

### DIFF
--- a/blaze/compute/csv.py
+++ b/blaze/compute/csv.py
@@ -6,9 +6,10 @@ from toolz import curry, concat
 import pandas as pd
 import numpy as np
 from collections import Iterator, Iterable
-from odo import into
+from odo import into, Temp
 from odo.chunks import chunks
 from odo.backends.csv import CSV
+from odo.backends.url import URL
 from multipledispatch import MDNotImplementedError
 
 from ..dispatch import dispatch
@@ -52,6 +53,11 @@ def pre_compute(expr, data, comfortable_memory=None, chunksize=2**18, **kwargs):
         return into(chunks(pd.DataFrame), data, dshape=leaf.dshape, **kwargs)
     else:
         return into(pd.DataFrame, data, dshape=leaf.dshape, **kwargs)
+
+
+@dispatch((Expr, Head), URL(CSV))
+def pre_compute(expr, data, **kwargs):
+    return pre_compute(expr, into(Temp(CSV), data, **kwargs), **kwargs)
 
 
 Cheap = (Head, ElemWise, Distinct, Symbol)

--- a/blaze/compute/tests/test_url_csv_compute.py
+++ b/blaze/compute/tests/test_url_csv_compute.py
@@ -1,0 +1,39 @@
+import pytest
+
+import os
+
+from blaze import Data, compute
+from blaze.utils import raises
+from odo import URL, CSV
+
+import pandas as pd
+import pandas.util.testing as tm
+
+from functools import partial
+
+try:
+    from urllib2 import urlopen
+    from urllib2 import HTTPError, URLError
+except ImportError:
+    from urllib.request import urlopen
+    from urllib.error import HTTPError, URLError
+
+pytestmark = pytest.mark.skipif(raises(URLError,
+                                       partial(urlopen, "http://google.com")),
+                                reason='unable to connect to google.com')
+
+iris_url = ('https://raw.githubusercontent.com/'
+            'blaze/blaze/master/blaze/examples/data/iris.csv')
+
+@pytest.fixture
+def iris_local():
+    thisdir = os.path.abspath(os.path.dirname(__file__))
+    return Data(os.path.join(thisdir, os.pardir, os.pardir, "examples", "data", "iris.csv"))
+
+def test_url_csv_data(iris_local):
+    iris_remote = Data(iris_url)
+    assert isinstance(iris_remote.data, URL(CSV))
+    iris_remote_df = compute(iris_remote)
+    assert isinstance(iris_remote_df, pd.DataFrame)
+    iris_local_df = compute(iris_local)
+    tm.assert_frame_equal(iris_remote_df, iris_local_df)

--- a/docs/source/whatsnew/0.9.0.txt
+++ b/docs/source/whatsnew/0.9.0.txt
@@ -26,6 +26,8 @@ Improved Backends
 * Adds support for :func:`~blaze.expr.collections.tail` in the sql backend
   (:issue:`1289`).
 * Blaze Server now supports dynamically adding datasets (:issue:`1329`).
+* Can now point :func:`~blaze.interactive.Data` to URLs of CSVs
+  (:issue:`1336`).
 
 Experimental Features
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Fixes issue #1336.

Further improvements may include expanding to support other formats
besides CSV.  URLs of CSVs is the major usecase here.

@llllllllll @cowlicks you mind taking a look?