### PR TITLE
Fix repr to work with partially bound expressions

### DIFF
--- a/blaze/interactive.py
+++ b/blaze/interactive.py
@@ -255,7 +255,7 @@ def coerce_scalar(result, dshape, odo_kwargs=None):
 
 def expr_repr(expr, n=10):
     # Pure Expressions, not interactive
-    if not expr._resources():
+    if not set(expr._resources().keys()).issuperset(expr._leaves()):
         return str(expr)
 
     # Scalars

--- a/blaze/tests/test_interactive.py
+++ b/blaze/tests/test_interactive.py
@@ -459,3 +459,16 @@ def test_pickle_roundtrip():
 def test_nameless_data():
     data = [('a', 1)]
     assert repr(data) in repr(Data(data))
+
+
+def test_partially_bound_expr():
+    df = pd.DataFrame([(1, 'Alice', 100),
+                       (2, 'Bob', -200),
+                       (3, 'Charlie', 300),
+                       (4, 'Denis', 400),
+                       (5, 'Edith', -500)],
+                      columns=['id', 'name', 'balance'])
+    data = Data(df, name='data')
+    a = symbol('a', 'int')
+    expr = data.name[data.balance > a]
+    assert repr(expr) == 'data[data.balance > a].name'


### PR DESCRIPTION
Previously, if you had an expression composed of both symbolics and `InteractiveSymbol` instances, the repr would call `compute`, which would error. This fixes that so that `compute` is only called for fully bound expressions (all leaves have data).

I left the `repr` alone for now (not touching #1356). As such, bound symbols will display only their name in an expression.

Fixes #1355.