### PR TITLE
Canonicalize blaze server dshape formatting.

### DIFF
--- a/blaze/server/server.py
+++ b/blaze/server/server.py
@@ -22,7 +22,7 @@ except ImportError:
 
 from toolz import assoc, valmap
 
-from datashape import Mono, discover
+from datashape import Mono, discover, pprint
 from datashape.predicates import iscollection, isscalar
 from odo import odo
 
@@ -222,7 +222,7 @@ class Server(object):
 @crossdomain(origin='*', methods=['GET'])
 @authorization
 def shape():
-    return str(discover(_get_data()))
+    return pprint(discover(_get_data()), width=0)
 
 
 def to_tree(expr, names=None):
@@ -431,7 +431,7 @@ def compserver(payload, serial):
         )
 
     return serial.dumps({
-        'datashape': str(expr.dshape),
+        'datashape': pprint(expr.dshape, width=0),
         'data': result,
         'names': expr.fields
     })

--- a/docs/source/whatsnew/0.9.0.txt
+++ b/docs/source/whatsnew/0.9.0.txt
@@ -62,6 +62,8 @@ API Changes
   default. Also, positional arguments are no longer forwarded to the inner flask
   app's ``run`` method. All keyword arguments not consumed by the blaze server
   ``run`` are still forwarded (:issue:`1316`).
+* :class:`~blaze.server.Server` represents datashapes in a canonical form with
+  consistent linebreaks for use by non-Python clients (:issue:`1361`).
 
 Bug Fixes
 ~~~~~~~~~


### PR DESCRIPTION
Non-Python clients (like JS) can get tripped up with different
formatting in dshapes.

For instance, small record dshapes, like:

    var * {a: int32, b: float64}

are stringified by default on one line, but longer dshapes, like:

    var * {
        sepal_length: float64,
        sepal_width: float64,
        petal_length: float64,
        petal_width: float64,
        species: ?string
        }

are stringified onto several lines.

This commit ensures that all datashapes are stringified in a consistent
way, regardless of the number of components in the dshape or the
dshape's overall string length.  Again, this is motivated by non-Python
clients that expect a consistent formatting for dshapes.

This has little effect for Python clients, as they can simply re-hydrate
the dshape on the client side and interact with the DataShape object
API.

The server tests were modified to not compare the string form of dshapes
directly; instead, they use `datashape.util.testing.assert_dshape_equal()`.

The long-term solution to this is to separate the serialization of
dshapes from their string representation.  This would involve defining
something like `to_tree()` and `from_tree()` for DataShape objects, and
allow clients to represent the serialized dshape contents however it
chooses.