### PR TITLE
FIX: Fix issue with `Like` selections on SQL selects.

### DIFF
--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -999,6 +999,13 @@ def compute_up(t, s, **kwargs):
     )
 
 
+@dispatch(Like, Select)
+def compute_up(t, s, **kwargs):
+    assert len(s.c) == 1, \
+            'Select cannot have more than a single column when filtering with `like`'
+    return compute_up(t, first(s.inner_columns), **kwargs)
+
+
 @dispatch(Like, ColumnElement)
 def compute_up(t, s, **kwargs):
     return s.like(t.pattern.replace('*', '%').replace('?', '_'))


### PR DESCRIPTION
`Like` only worked on `ColumnElement`s in sql.py.  This led to
`NotImplementedError`s when calling `like()` on a column of a SQL join for example,
which this commit fixes.

@llllllllll @cpcloud can you take a look?

ping @sandhujasmine