### PR TITLE
FIX: `is` test in `Expr.__eq__`.

### DIFF
--- a/blaze/expr/core.py
+++ b/blaze/expr/core.py
@@ -189,6 +189,9 @@ class Node(object):
         self.__init__(*state)
 
     def __eq__(self, other):
+        if self is other:
+            return True
+
         ident = self.isidentical(other)
         if ident is True:
             return ident


### PR DESCRIPTION
Shortcuts some expensive `isidentical()` checks for when comparing an
object with itself.

ping @jcrist 