### PR TITLE
Allow extra per-dataset arguments in blaze server yaml file.

### DIFF
--- a/blaze/server/spider.py
+++ b/blaze/server/spider.py
@@ -103,7 +103,8 @@ def from_yaml(path, ignore=(ValueError, NotImplementedError), followlinks=True,
         if 'source' not in info:
             raise ValueError('source key not found for data source named %r' %
                              name)
-        map(importlib.import_module, info.pop('imports', []))
+        for mod in info.pop('imports', []):
+            importlib.import_module(mod)
         source = info['source']
         if os.path.isdir(source) and info.get('recurse', False):
             extra_kwargs = toolz.dissoc(info, 'source', 'recurse')

--- a/blaze/server/spider.py
+++ b/blaze/server/spider.py
@@ -106,22 +106,21 @@ def from_yaml(path, ignore=(ValueError, NotImplementedError), followlinks=True,
     """
     resources = {}
     for name, info in yaml.load(path.read()).items():
-        if 'source' not in info:
+        try:
+            source = info.pop('source')
+        except KeyError:
             raise ValueError('source key not found for data source named %r' %
                              name)
         for mod in info.pop('imports', []):
             importlib.import_module(mod)
-        source = info['source']
-        if os.path.isdir(source) and info.get('recurse', False):
-            extra_kwargs = toolz.dissoc(info, 'source', 'recurse')
+        if os.path.isdir(source):
             resources[name] = data_spider(os.path.expanduser(source),
                                           ignore=ignore,
                                           followlinks=followlinks,
                                           hidden=hidden,
-                                          extra_kwargs=extra_kwargs)
+                                          extra_kwargs=info)
         else:
-            extra_kwargs = toolz.dissoc(info, 'source')
-            resources[name] = resource(source, **extra_kwargs)
+            resources[name] = resource(source, **info)
     return resources
 
 

--- a/docs/source/server.rst
+++ b/docs/source/server.rst
@@ -75,9 +75,9 @@ The structure of the specification file is as follows:
      name1:
        source: path or uri
        dshape: optional datashape
-     name2:
+     directory2:
        source: path or uri
-       dshape: optional datashape
+       recurse: True
      ...
      nameN:
        source: path or uri
@@ -85,7 +85,7 @@ The structure of the specification file is as follows:
 
 .. note::
 
-   When ``source`` is a directory, Blaze will recurse into the directory tree and call ``odo.resource`` on the leaves of the tree.
+   When ``source`` is a directory, and there is a `recurse: True` flag to mark it as such,  Blaze will recurse into the directory tree and call ``odo.resource`` on the leaves of the tree.
 
 Here's an example specification file:
 
@@ -116,6 +116,18 @@ The previous YAML specification will serve the following dictionary:
 The only required key for each named data source is the ``source`` key, which
 is passed to ``odo.resource``. You can optionally specify a ``dshape``
 parameter, which is passed into ``odo.resource`` along with the ``source`` key.
+
+If ``odo.resource`` requires extra keyword arguments for a particular resource
+type and they are provided in the YAML file, these will be forwarded on to the
+``resource`` call:
+
+  .. code-block:: yaml
+
+     name1:
+         source: path or uri
+         dshape: optional datashape
+         kwarg1: extra kwarg
+         kwarg2: etc.
 
 Command Line Interface
 ----------------------
@@ -169,9 +181,9 @@ The highest level of abstraction and the level that most will probably want to
 work at is interactively sending computations to a Blaze server process from a
 client.
 
-We can use Blaze server to have one Blaze process control another.
-Given our iris web server we can use Blaze on the client to drive the server to
-do work for us
+We can use Blaze server to have one Blaze process control another.  Given our
+iris web server we can use Blaze on the client to drive the server to do work
+for us
 
 .. code-block:: python
 

--- a/docs/source/server.rst
+++ b/docs/source/server.rst
@@ -75,9 +75,9 @@ The structure of the specification file is as follows:
      name1:
        source: path or uri
        dshape: optional datashape
-     directory2:
+     name2:
        source: path or uri
-       recurse: True
+       dshape: optional datashape
      ...
      nameN:
        source: path or uri
@@ -85,7 +85,8 @@ The structure of the specification file is as follows:
 
 .. note::
 
-   When ``source`` is a directory, and there is a `recurse: True` flag to mark it as such,  Blaze will recurse into the directory tree and call ``odo.resource`` on the leaves of the tree.
+  When ``source`` is a directory, Blaze will recurse into the directory tree
+  and call ``odo.resource`` on the leaves of the tree.
 
 Here's an example specification file:
 
@@ -117,9 +118,18 @@ The only required key for each named data source is the ``source`` key, which
 is passed to ``odo.resource``. You can optionally specify a ``dshape``
 parameter, which is passed into ``odo.resource`` along with the ``source`` key.
 
+Advanced YAML usage
+-------------------
+
 If ``odo.resource`` requires extra keyword arguments for a particular resource
 type and they are provided in the YAML file, these will be forwarded on to the
-``resource`` call:
+``resource`` call.  
+
+If there is an ``imports`` entry for a resource whose value is a list of module
+or package names, Blaze server will ``import`` each of these modules or
+packages before calling ``resource``.
+
+For example:
 
   .. code-block:: yaml
 
@@ -128,6 +138,16 @@ type and they are provided in the YAML file, these will be forwarded on to the
          dshape: optional datashape
          kwarg1: extra kwarg
          kwarg2: etc.
+     name2:
+         source: path or uri
+         imports: ['mod1', 'pkg2']
+
+For this YAML file, Blaze server will pass on ``kwarg1=...`` and ``kwarg2=...``
+to the ``resource()`` call for ``name1`` in addition to the ``dshape=...``
+keyword argument.
+
+Also, before calling ``resource`` on the ``source`` of ``name2``, Blaze server
+will first execute an ``import mod1`` and ``import pkg2`` statement.
 
 Command Line Interface
 ----------------------


### PR DESCRIPTION
Extra arguments are passed through to underlying `resource()` call.

Required for some custom backends.

Adds `imports` option that will trigger imports of listed packages before `resource()` call.

Example `blaze-server` yaml file with a single dataset `ds1` and a directory of datasets `dir`:

```
ds1:
    source: "foo://bar/baz"
    dshape: "var * {...}"
    extra_arg: 1
    extra_arg2: "spam!"
    imports: ["foo", "custom_module"]
ds2:
    source: "./dir"
    dshape: "..."
```

Note that this is strictly expanding functionality and will not affect existing Blaze server behavior with YAML spec files.