### PR TITLE
Use flask-cors package for CORS; don't use Bokeh anymore.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,9 @@ install:
 
   - pip install psycopg2
 
+  # Install flask-cors
+  - pip install flask-cors
+
   # blaze required deps
   - pip install git+https://github.com/blaze/datashape
   - pip install git+https://github.com/blaze/odo

--- a/blaze/server/server.py
+++ b/blaze/server/server.py
@@ -8,17 +8,7 @@ import collections
 
 import flask
 from flask import Blueprint, Flask, request, Response
-
-try:
-    from bokeh.server.crossdomain import crossdomain
-except ImportError:
-    def crossdomain(*args, **kwargs):
-        def wrapper(f):
-            @functools.wraps(f)
-            def wrapped(*a, **k):
-                return f(*a, **k)
-            return wrapped
-        return wrapper
+from flask.ext.cors import cross_origin
 
 from toolz import assoc, valmap
 
@@ -219,7 +209,7 @@ class Server(object):
 
 
 @api.route('/datashape', methods=['GET'])
-@crossdomain(origin='*', methods=['GET'])
+@cross_origin(origins='*', methods=['GET'])
 @authorization
 def shape():
     return pprint(discover(_get_data()), width=0)
@@ -399,7 +389,7 @@ mimetype_regex = re.compile(r'^application/vnd\.blaze\+(%s)$' %
 
 
 @api.route('/compute', methods=['POST', 'HEAD', 'OPTIONS'])
-@crossdomain(origin='*', methods=['POST', 'HEAD', 'OPTIONS'])
+@cross_origin(origins='*', methods=['POST', 'HEAD', 'OPTIONS'])
 @authorization
 @check_request
 def compserver(payload, serial):
@@ -437,7 +427,7 @@ def compserver(payload, serial):
     })
 
 @api.route('/add', methods=['POST', 'HEAD', 'OPTIONS'])
-@crossdomain(origin='*', methods=['POST', 'HEAD', 'OPTIONS'])
+@cross_origin(origins='*', methods=['POST', 'HEAD', 'OPTIONS'])
 @authorization
 @check_request
 def addserver(payload, serial):

--- a/docs/source/whatsnew/0.9.1.txt
+++ b/docs/source/whatsnew/0.9.1.txt
@@ -1,0 +1,33 @@
+Release |version|
+-----------------
+
+:Release: |version|
+:Date: December 17th, 2015
+
+New Expressions
+~~~~~~~~~~~~~~~
+
+Improved Expressions
+~~~~~~~~~~~~~~~~~~~~
+
+New Backends
+~~~~~~~~~~~~
+
+Improved Backends
+~~~~~~~~~~~~~~~~~
+
+* Blaze Server no longer depends on `Bokeh` for CORS handling, and now uses the
+  `flask-cors` third-party package (:issue:`1378`).
+
+Experimental Features
+~~~~~~~~~~~~~~~~~~~~~
+
+API Changes
+~~~~~~~~~~~
+
+Bug Fixes
+~~~~~~~~~
+
+Miscellaneous
+~~~~~~~~~~~~~
+


### PR DESCRIPTION
With Bokeh 0.11, the CORS handling was moved.  This removes the Bokeh
dependency for this part of Blaze and uses instead a small MIT-licensed
flask extension.