### PR TITLE
timedelta improvements

### DIFF
--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -46,6 +46,7 @@ from multipledispatch import MDNotImplementedError
 
 from odo.backends.sql import metadata_of_engine, dshape_to_alchemy
 
+from datashape import TimeDelta
 from datashape.predicates import iscollection, isscalar, isrecord
 
 from ..dispatch import dispatch
@@ -58,7 +59,7 @@ from ..expr import (
     Join, mean, var, std, Reduction, count, FloorDiv, UnaryStringFunction,
     strlen, DateTime, Coerce, nunique, Distinct, By, Sort, Head, Tail, Label,
     Concat, ReLabel, Merge, common_subexpression, Summary, Like, nelements,
-    notnull, Shift, BinaryMath, Pow, DateTimeTruncate,
+    notnull, Shift, BinaryMath, Pow, DateTimeTruncate, Sub,
 )
 
 from ..expr.broadcast import broadcast_collect
@@ -207,7 +208,7 @@ def compute_up(t, lhs, rhs, **kwargs):
     return select(lhs).union_all(select(rhs)).alias()
 
 
-@dispatch(Broadcast, sa.Column)
+@dispatch(Broadcast, ColumnElement)
 def compute_up(t, s, **kwargs):
     expr = t._scalar_expr
     return compute(expr, s, post_compute=False).label(expr._name)
@@ -1108,9 +1109,28 @@ def engine_of(x):
     raise NotImplementedError("Can't deterimine engine of %s" % x)
 
 
-@dispatch(Expr)
+@dispatch(object)
 def _subexpr_optimize(expr):
     return expr
+
+
+@dispatch(Expr)
+def _subexpr_optimize(expr):
+    return type(expr)(*map(_subexpr_optimize, expr._args))
+
+
+timedelta_ns = TimeDelta(unit='ns')
+
+
+@dispatch(Sub)
+def _subexpr_optimize(expr):
+    new_expr = type(expr)(*map(_subexpr_optimize, expr._args))
+    schema = expr.schema
+    # we have a timedelta shaped expression; sql timedeltas are in `ns` units
+    # so we should coerce this exprssion over
+    if isinstance(schema, TimeDelta) and schema.unit != 'ns':
+        new_expr = new_expr.coerce(timedelta_ns)
+    return new_expr
 
 
 @dispatch(Tail)

--- a/blaze/compute/tests/test_numpy_compute.py
+++ b/blaze/compute/tests/test_numpy_compute.py
@@ -526,6 +526,10 @@ def test_timedelta_arith():
     sym = symbol('s', discover(dates))
     assert (compute(sym + delta, dates) == dates + delta).all()
     assert (compute(sym - delta, dates) == dates - delta).all()
+    assert (
+        compute(sym - (sym - delta), dates) ==
+        dates - (dates - delta)
+    ).all()
 
 
 def test_coerce():

--- a/blaze/compute/tests/test_pandas_compute.py
+++ b/blaze/compute/tests/test_pandas_compute.py
@@ -799,6 +799,10 @@ def test_timedelta_arith():
     delta = timedelta(days=1)
     assert (compute(sym + delta, series) == series + delta).all()
     assert (compute(sym - delta, series) == series - delta).all()
+    assert (
+        compute(sym - (sym - delta), series) ==
+        series - (series - delta)
+    ).all()
 
 
 def test_coerce_series():

--- a/blaze/compute/tests/test_pandas_compute.py
+++ b/blaze/compute/tests/test_pandas_compute.py
@@ -805,6 +805,16 @@ def test_timedelta_arith():
     ).all()
 
 
+@pytest.mark.parametrize('func,expected', (
+    ('var', timedelta(0, 8, 250000)),
+    ('std', timedelta(0, 2, 872281)),
+))
+def test_timedelta_stat_reduction(func, expected):
+    deltas = pd.Series([timedelta(seconds=n) for n in range(10)])
+    sym = symbol('s', discover(deltas))
+    assert compute(getattr(sym, func)(), deltas) == expected
+
+
 def test_coerce_series():
     s = pd.Series(list('123'), name='a')
     t = symbol('t', discover(s))

--- a/blaze/compute/tests/test_postgresql_compute.py
+++ b/blaze/compute/tests/test_postgresql_compute.py
@@ -102,6 +102,20 @@ def sql_with_dts(url):
 
 
 @pytest.yield_fixture
+def sql_with_timedeltas(url):
+    try:
+        t = resource(url % next(names), dshape='var * {N: timedelta}')
+    except sa.exc.OperationalError as e:
+        pytest.skip(str(e))
+    else:
+        t = odo([(timedelta(seconds=n),) for n in range(10)], t)
+        try:
+            yield t
+        finally:
+            drop(t)
+
+
+@pytest.yield_fixture
 def sql_two_tables(url):
     dshape = 'var * {a: int32}'
     try:
@@ -305,6 +319,18 @@ def test_timedelta_arith(sql_with_dts):
         odo(compute(sym - (sym - delta), sql_with_dts), pd.Series) ==
         dates - (dates - delta)
     ).all()
+
+
+@pytest.mark.parametrize('func', ('var', 'std'))
+def test_timedelta_stat_reduction(sql_with_timedeltas, func):
+    sym = symbol('s', discover(sql_with_timedeltas))
+    expr = getattr(sym.N, func)()
+
+    deltas = pd.Series([timedelta(seconds=n) for n in range(10)])
+    expected = timedelta(
+        seconds=getattr(deltas.astype('int64') / 1e9, func)(ddof=expr.unbiased)
+    )
+    assert odo(compute(expr, sql_with_timedeltas), timedelta) == expected
 
 
 def test_coerce_bool_and_sum(sql):

--- a/blaze/compute/tests/test_postgresql_compute.py
+++ b/blaze/compute/tests/test_postgresql_compute.py
@@ -301,6 +301,10 @@ def test_timedelta_arith(sql_with_dts):
     assert (
         odo(compute(sym - delta, sql_with_dts), pd.Series) == dates - delta
     ).all()
+    assert (
+        odo(compute(sym - (sym - delta), sql_with_dts), pd.Series) ==
+        dates - (dates - delta)
+    ).all()
 
 
 def test_coerce_bool_and_sum(sql):

--- a/blaze/expr/arithmetic.py
+++ b/blaze/expr/arithmetic.py
@@ -4,7 +4,7 @@ import operator
 from toolz import first
 import numpy as np
 import pandas as pd
-from datashape import dshape, var, DataShape, Option
+from datashape import dshape, var, DataShape, Option, datetime_, timedelta_
 from dateutil.parser import parse as dt_parse
 from datashape.predicates import isscalar, isboolean, isnumeric, isdatelike
 from datashape import coretypes as ct, discover, unsigned, promote, optionify
@@ -174,6 +174,15 @@ class Repeat(Arithmetic):
 class Sub(Arithmetic):
     symbol = '-'
     op = operator.sub
+
+    @property
+    def _dtype(self):
+        if (discover(self.lhs).measure == datetime_ and
+            discover(self.rhs).measure == datetime_):
+
+            return timedelta_
+
+        return super(Sub, self)._dtype
 
 
 class Div(Arithmetic):

--- a/blaze/expr/arithmetic.py
+++ b/blaze/expr/arithmetic.py
@@ -177,10 +177,12 @@ class Sub(Arithmetic):
 
     @property
     def _dtype(self):
-        if (discover(self.lhs).measure == datetime_ and
-            discover(self.rhs).measure == datetime_):
+        lmeasure = discover(self.lhs).measure
+        rmeasure = discover(self.rhs).measure
+        if (getattr(lmeasure, 'ty', lmeasure) == datetime_ and
+            getattr(rmeasure, 'ty', rmeasure) == datetime_):
 
-            return timedelta_
+            return optionify(lmeasure, rmeasure, timedelta_)
 
         return super(Sub, self)._dtype
 

--- a/blaze/expr/arithmetic.py
+++ b/blaze/expr/arithmetic.py
@@ -4,10 +4,24 @@ import operator
 from toolz import first
 import numpy as np
 import pandas as pd
-from datashape import dshape, var, DataShape, Option, datetime_, timedelta_
-from dateutil.parser import parse as dt_parse
+from datashape import (
+    DataShape,
+    DateTime,
+    Option,
+    TimeDelta,
+    coretypes as ct,
+    datetime_,
+    discover,
+    dshape,
+    optionify,
+    promote,
+    timedelta_,
+    unsigned,
+    var,
+)
 from datashape.predicates import isscalar, isboolean, isnumeric, isdatelike
-from datashape import coretypes as ct, discover, unsigned, promote, optionify
+from dateutil.parser import parse as dt_parse
+
 
 from .core import parenthesize, eval_str
 from .expressions import Expr, shape, ElemWise
@@ -159,6 +173,30 @@ class Add(Arithmetic):
     symbol = '+'
     op = operator.add
 
+    @property
+    def _dtype(self):
+        lmeasure = discover(self.lhs).measure
+        lty = getattr(lmeasure, 'ty', lmeasure)
+        rmeasure = discover(self.rhs).measure
+        rty = getattr(rmeasure, 'ty', rmeasure)
+        if lmeasure == datetime_ and rmeasure == datetime_:
+            raise TypeError('cannot add datetime to datetime')
+
+        l_is_datetime = lty == datetime_
+        if l_is_datetime or rty == datetime_:
+            if l_is_datetime:
+                other = rty
+            else:
+                other = lty
+            if isinstance(other, TimeDelta):
+                return optionify(lmeasure, rmeasure, datetime_)
+            else:
+                raise TypeError(
+                    'can only add timedeltas to datetimes',
+                )
+
+        return super(Add, self)._dtype
+
 
 class Mult(Arithmetic):
     symbol = '*'
@@ -178,11 +216,18 @@ class Sub(Arithmetic):
     @property
     def _dtype(self):
         lmeasure = discover(self.lhs).measure
+        lty = getattr(lmeasure, 'ty', lmeasure)
         rmeasure = discover(self.rhs).measure
-        if (getattr(lmeasure, 'ty', lmeasure) == datetime_ and
-            getattr(rmeasure, 'ty', rmeasure) == datetime_):
-
-            return optionify(lmeasure, rmeasure, timedelta_)
+        rty = getattr(rmeasure, 'ty', rmeasure)
+        if lty == datetime_:
+            if isinstance(rty, DateTime):
+                return optionify(lmeasure, rmeasure, timedelta_)
+            if isinstance(rty, TimeDelta):
+                return optionify(lmeasure, rmeasure, datetime_)
+            else:
+                raise TypeError(
+                    'can only subtract timedelta or datetime from datetime',
+                )
 
         return super(Sub, self)._dtype
 

--- a/blaze/expr/reductions.py
+++ b/blaze/expr/reductions.py
@@ -127,7 +127,11 @@ class FloatingReduction(Reduction):
         base = getattr(measure, 'ty', measure)
         return_type = Option if isinstance(measure, Option) else toolz.identity
         return DataShape(return_type(
-            base if isinstance(base, Decimal) else ct.float64
+            base
+            if isinstance(base, Decimal) else
+            base
+            if isinstance(base, TimeDelta) else
+            ct.float64,
         ))
 
 
@@ -313,7 +317,7 @@ dshape_method_list.extend([
     (iscollection, set([count, nelements])),
     (lambda ds: (iscollection(ds) and
                  (isstring(ds) or isnumeric(ds) or isboolean(ds) or
-                  isdatelike(ds) or isinstance(ds, TimeDelta))),
+                  isdatelike(ds))),
      set([min, max])),
     (lambda ds: len(ds.shape) == 1,
      set([nrows, nunique])),

--- a/blaze/expr/tests/test_arithmetic.py
+++ b/blaze/expr/tests/test_arithmetic.py
@@ -21,6 +21,8 @@ g = symbol('g', 'datetime')
 h = symbol('h', 'datetime')
 i = symbol('i', '?datetime')
 j = symbol('j', '?datetime')
+k = symbol('k', 'timedelta')
+l = symbol('l', '?timedelta')
 optionals = {d, e, f}
 
 
@@ -115,3 +117,14 @@ def test_datetime_sub():
     assert (g - h).dshape == dshape('timedelta')
     assert (g - i).dshape == dshape('?timedelta')
     assert (i - j).dshape == dshape('?timedelta')
+    assert (g - k).dshape == dshape('datetime')
+    assert (g - l).dshape == dshape('?datetime')
+    assert (i - k).dshape == dshape('?datetime')
+    assert (i - l).dshape == dshape('?datetime')
+
+
+def test_datetime_add():
+    assert (g + k).dshape == dshape('datetime')
+    assert (g + l).dshape == dshape('?datetime')
+    assert (i + k).dshape == dshape('?datetime')
+    assert (i + l).dshape == dshape('?datetime')

--- a/blaze/expr/tests/test_arithmetic.py
+++ b/blaze/expr/tests/test_arithmetic.py
@@ -17,6 +17,10 @@ cs = symbol('cs', 'string')
 d = symbol('d', '5*3*?int32')
 e = symbol('e', '?int32')
 f = symbol('f', '?bool')
+g = symbol('g', 'datetime')
+h = symbol('h', 'datetime')
+i = symbol('i', '?datetime')
+j = symbol('j', '?datetime')
 optionals = {d, e, f}
 
 
@@ -105,3 +109,9 @@ def test_str_arith():
 
     with pytest.raises(Exception):
         cs // 1
+
+
+def test_datetime_sub():
+    assert (g - h).dshape == dshape('timedelta')
+    assert (g - i).dshape == dshape('?timedelta')
+    assert (i - j).dshape == dshape('?timedelta')

--- a/blaze/expr/tests/test_reductions.py
+++ b/blaze/expr/tests/test_reductions.py
@@ -105,3 +105,10 @@ def test_decimal_reduction(func):
     t = symbol('t', 'var * decimal[11, 2]')
     method = getattr(t, func)
     assert_dshape_equal(method().dshape, dshape("decimal[11, 2]"))
+
+
+@pytest.mark.parametrize('func', ['sum', 'mean', 'std', 'var'])
+def test_timedelta_reduction(func):
+    t = symbol('t', 'var * timedelta')
+    method = getattr(t, func)
+    assert_dshape_equal(method().dshape, dshape("timedelta"))

--- a/blaze/interactive.py
+++ b/blaze/interactive.py
@@ -8,9 +8,6 @@ import itertools
 import operator
 import warnings
 
-from collections import Iterator
-from functools import reduce
-
 import datashape
 from datashape import discover, Tuple, Record, DataShape, var, Map
 from datashape.predicates import iscollection, isscalar, isrecord, istabular
@@ -249,6 +246,8 @@ def coerce_scalar(result, dshape, odo_kwargs=None):
         return coerce_(Timestamp)
     elif 'date' in dshape:
         return coerce_(datetime.date)
+    elif 'timedelta' in dshape:
+        return coerce_(datetime.timedelta)
     else:
         return result
 

--- a/blaze/tests/test_interactive.py
+++ b/blaze/tests/test_interactive.py
@@ -380,6 +380,13 @@ def test_coerce_date_and_datetime():
     assert repr(d) == repr(pd.NaT)
 
 
+def test_coerce_timedelta():
+    x = datetime.timedelta(days=1, hours=2, minutes=3)
+    d = Data(x)
+
+    assert repr(d) == repr(x)
+
+
 def test_highly_nested_repr():
     data = [[0, [[1, 2], [3]], 'abc']]
     d = Data(data)

--- a/docs/source/whatsnew/0.9.1.txt
+++ b/docs/source/whatsnew/0.9.1.txt
@@ -14,9 +14,13 @@ Improved Expressions
   general ``Select`` queries that result from
   :class:`~blaze.expr.collections.Join` operations rather than soely
   ``ColumnElement`` queries (:issue:`1371` :issue:`1373`).
+* Adds ``std`` and ``var`` reductions for ``timedelta`` types for sql and pandas
+  backends (:issue:`1382`).
 
 New Backends
 ~~~~~~~~~~~~
+
+None
 
 Improved Backends
 ~~~~~~~~~~~~~~~~~
@@ -27,8 +31,12 @@ Improved Backends
 Experimental Features
 ~~~~~~~~~~~~~~~~~~~~~
 
+None
+
 API Changes
 ~~~~~~~~~~~
+
+None
 
 Bug Fixes
 ~~~~~~~~~
@@ -48,6 +56,14 @@ Bug Fixes
   like ``s[s.a == s.a[s.a == 1]].a`` would turn into ``s[s.a == s.a].a`` because
   we would pull the inner column out of the ``s[s.a == 1]`` and lose the filter
   (:issue:`1396`).
+* Fixed a type issue where ``datetime - datetime :: datetime`` instead of
+  ``timedelta`` (:issue:`1382`).
+* Fixed a bug that prevented :func:`~blaze.expr.expressions.coerce` to fail when
+  computing against ``ColumnElement``\s. This would break ``coerce`` for many
+  sql operations (:issue:`1382`).
+* Fixed reductions over ``timedelta`` returning ``float`` (:issue:`1382`).
+* Fixed interactive repr for ``timedelta`` not coercing to ``timedelta``
+  objects (:issue:`1382`).
 
 Miscellaneous
 ~~~~~~~~~~~~~


### PR DESCRIPTION
depends on: https://github.com/blaze/odo/pull/394 (merged) and https://github.com/blaze/datashape/pull/207 (merged)

This adds:

* `datetime - datetime :: timedelta`
* `datetime - timedelta :: datetime`
* `datetime + timedelta :: datetime`
* support for those cases where lhs, rhs, or both are optional
* reductions over `timedelta` are of type `timedelta` not `float`
* adds `std` and `var` to timedelta in pandas and sql. This requires coercing to int to do the reduction then coercing back because neither pandas or postgres support this nativly.
* corrected datetime subtraction coercing in postgres. Done at expression time with `optimize`

When we are ready to update the type checking for operators these tests will help a lot. I hope that soon we can have some type of datashape based registration / type checking like:

```python
@typecheck('(Integral, Integral) -> Integral')
@typecheck('(datetime, timedelta) -> timedelta')
class add(Arithmetic):
    pass
```