### PR TITLE
Rename blaze.server.spider.spider to data_spider.

### DIFF
--- a/blaze/server/__init__.py
+++ b/blaze/server/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 from .server import Server, to_tree, from_tree, api
-from .spider import spider, from_yaml
+from .spider import data_spider, from_yaml
 from .client import Client
 from .serialization import (
     SerializationFormat,
@@ -16,7 +16,7 @@ __all__ = [
     'Client',
     'SerializationFormat',
     'Server',
-    'spider',
+    'data_spider',
     'from_yaml',
     'all_formats',
     'api',

--- a/blaze/server/spider.py
+++ b/blaze/server/spider.py
@@ -19,7 +19,7 @@ except ImportError:
     import builtins
 
 
-__all__ = 'spider', 'from_yaml'
+__all__ = 'data_spider', 'from_yaml'
 
 
 def _spider(resource_path, ignore, followlinks, hidden):
@@ -41,9 +41,11 @@ def _spider(resource_path, ignore, followlinks, hidden):
     return resources
 
 
-def spider(path, ignore=(ValueError, NotImplementedError), followlinks=True,
-           hidden=False):
-    """Traverse a directory and call ``odo.resource`` on its contentso
+def data_spider(path,
+                ignore=(ValueError, NotImplementedError),
+                followlinks=True,
+                hidden=False):
+    """Traverse a directory and call ``odo.resource`` on its contents.
 
     Parameters
     ----------
@@ -61,6 +63,8 @@ def spider(path, ignore=(ValueError, NotImplementedError), followlinks=True,
     dict
         Possibly nested dictionary of containing basenames mapping to resources
     """
+    # NOTE: this is named `data_spider` rather than just `spider` to
+    # disambiguate this function from the `blaze.server.spider` module.
     return {
         os.path.basename(path): _spider(path, ignore=ignore,
                                         followlinks=followlinks,
@@ -90,7 +94,7 @@ def from_yaml(path, ignore=(ValueError, NotImplementedError), followlinks=True,
 
     See Also
     --------
-    spider : Traverse a directory tree for resources
+    data_spider : Traverse a directory tree for resources
     """
     resources = {}
     for name, info in yaml.load(path.read()).items():
@@ -99,10 +103,10 @@ def from_yaml(path, ignore=(ValueError, NotImplementedError), followlinks=True,
                              name)
         source = info['source']
         if os.path.isdir(source):
-            resources[name] = spider(os.path.expanduser(source),
-                                     ignore=ignore,
-                                     followlinks=followlinks,
-                                     hidden=hidden)
+            resources[name] = data_spider(os.path.expanduser(source),
+                                          ignore=ignore,
+                                          followlinks=followlinks,
+                                          hidden=hidden)
         else:
             resources[name] = resource(source, dshape=info.get('dshape'))
     return resources

--- a/blaze/server/tests/test_spider.py
+++ b/blaze/server/tests/test_spider.py
@@ -10,7 +10,7 @@ import pandas as pd
 
 from datashape import dshape
 
-from blaze import spider, discover
+from blaze import data_spider, discover
 
 
 @pytest.fixture
@@ -39,8 +39,8 @@ def data_with_cycle(data):
     return data
 
 
-def test_spider(data):
-    result = spider(str(data))
+def test_data_spider(data):
+    result = data_spider(str(data))
     ss = """{
     %r: {
         'foo.csv': var * {a: int64, b: int64},
@@ -53,8 +53,8 @@ def test_spider(data):
 
 @pytest.mark.skipif(sys.platform == 'win32',
                     reason='Windows does not have symlinks')
-def test_spider_cycle(data_with_cycle):
-    result = spider(str(data_with_cycle), followlinks=True)
+def test_data_spider_cycle(data_with_cycle):
+    result = data_spider(str(data_with_cycle), followlinks=True)
     ss = """{
     %r: {
         'foo.csv': var * {a: int64, b: int64},

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -78,7 +78,7 @@ Additional Server Utilities
 
 .. autosummary::
 
-   spider
+   data_spider
    from_yaml
 
 Definitions

--- a/docs/source/whatsnew/0.9.1.txt
+++ b/docs/source/whatsnew/0.9.1.txt
@@ -28,6 +28,10 @@ API Changes
 Bug Fixes
 ~~~~~~~~~
 
+* Fixed a ``blaze-server`` entry point bug regarding an ambiguity between the
+  :func:`~blaze.server.spider.spider` function and the
+  :module:`~blaze.server.spider` module (:issue:`1385`).
+
 Miscellaneous
 ~~~~~~~~~~~~~
 


### PR DESCRIPTION
Disambiguates the blaze.server.spider module from the data_spider
function.

Closes #1384.