### PR TITLE
Remove support for Spark 1.3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ matrix:
   fast_finish: true
   include:
     - python: 2.7
-      env: SPARK_VERSION=1.3
-    - python: 2.7
       env: SPARK_VERSION=1.4
     - python: 2.7
       env: SPARK_VERSION=1.5

--- a/docs/source/whatsnew/0.9.1.txt
+++ b/docs/source/whatsnew/0.9.1.txt
@@ -36,3 +36,4 @@ Bug Fixes
 Miscellaneous
 ~~~~~~~~~~~~~
 
+* Removed support for Spark 1.3 (:issue:`1386`) based on community consensus.


### PR DESCRIPTION
Consensus is that Spark 1.3 isn't worth supporting anymore.