### PR TITLE
BUG: correct isidentical for interactive symbols backed with nans

### DIFF
--- a/blaze/expr/core.py
+++ b/blaze/expr/core.py
@@ -19,7 +19,6 @@ __all__ = ['Node', 'path', 'common_subexpression', 'eval_str']
 
 
 base = (numbers.Number,) + _strtypes
-arrtypes = np.ndarray, pd.core.generic.NDFrame
 
 
 def isidentical(a, b):
@@ -49,12 +48,10 @@ def isidentical(a, b):
     """
     if isinstance(a, base) and isinstance(b, base):
         return a == b
-    if isinstance(a, arrtypes) and isinstance(b, arrtypes):
-        return np.array_equal(a, b)
     if type(a) != type(b):
         return False
     if isinstance(a, Node):
-        return all(map(isidentical, a._args, b._args))
+        return all(map(isidentical, a._hashargs, b._hashargs))
     if isinstance(a, (list, tuple)) and isinstance(b, (list, tuple)):
         return len(a) == len(b) and all(map(isidentical, a, b))
     return a == b

--- a/blaze/tests/test_interactive.py
+++ b/blaze/tests/test_interactive.py
@@ -3,6 +3,7 @@ import sys
 from types import MethodType
 
 from datashape import dshape
+from datashape.util.testing import assert_dshape_equal
 import pandas as pd
 import pandas.util.testing as tm
 import pytest
@@ -452,8 +453,9 @@ def test_pickle_roundtrip():
     assert ds.isidentical(pickle.loads(pickle.dumps(ds)))
     assert (ds + 1).isidentical(pickle.loads(pickle.dumps(ds + 1)))
     es = Data(np.array([1, 2, 3]))
-    assert es.isidentical(pickle.loads(pickle.dumps(es)))
-    assert (es + 1).isidentical(pickle.loads(pickle.dumps(es + 1)))
+    rs = pickle.loads(pickle.dumps(es))
+    assert (es.data == rs.data).all()
+    assert_dshape_equal(es.dshape, rs.dshape)
 
 
 def test_nameless_data():
@@ -472,3 +474,10 @@ def test_partially_bound_expr():
     a = symbol('a', 'int')
     expr = data.name[data.balance > a]
     assert repr(expr) == 'data[data.balance > a].name'
+
+
+def test_isidentical_regr():
+    # regression test for #1387
+    data = np.array([(np.nan,), (np.nan,)], dtype=[('a', 'float64')])
+    ds = Data(data)
+    assert ds.a.isidentical(ds.a)

--- a/docs/source/whatsnew/0.9.1.txt
+++ b/docs/source/whatsnew/0.9.1.txt
@@ -38,6 +38,10 @@ Bug Fixes
   :module:`~blaze.server.spider` module (:issue:`1385`).
 * Fixed :func:`blaze.expr.datetime.truncate` handling for the sql backend
   (:issue:`1393`).
+* Fix :func:`blaze.expr.core.isidentical` to check the ``_hashargs`` instead of
+  the ``_args``. This fixes a case that caused objects that hashed the same to
+  not compare equal when somewhere in the tree of ``_args`` was a non hashable
+  structure (:issue:`1387`).
 
 Miscellaneous
 ~~~~~~~~~~~~~


### PR DESCRIPTION
Fixes an infinite recursion error that would occur when comparing equality equality against fields of a bound symbol where the resource was an ndarray or ndframe with `nan`s

This goes back to the old behavior of not checking the arrays. This is really slow anyways.

I would really prefer to merge:  #1348 over this pr