### PR TITLE
BUG: sql truncate

### DIFF
--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -58,7 +58,7 @@ from ..expr import (
     Join, mean, var, std, Reduction, count, FloorDiv, UnaryStringFunction,
     strlen, DateTime, Coerce, nunique, Distinct, By, Sort, Head, Tail, Label,
     Concat, ReLabel, Merge, common_subexpression, Summary, Like, nelements,
-    notnull, Shift, BinaryMath, Pow,
+    notnull, Shift, BinaryMath, Pow, DateTimeTruncate,
 )
 
 from ..expr.broadcast import broadcast_collect
@@ -1069,6 +1069,11 @@ def compute_up(expr, data, **kwargs):
         return sa.func.date(data).label(expr._name)
 
     return sa.extract(expr.attr, data).label(expr._name)
+
+
+@dispatch(DateTimeTruncate, ColumnElement)
+def compute_up(expr, data, **kwargs):
+    return sa.func.date_trunc(expr.unit, data).label(expr._name)
 
 
 @compiles(sa.sql.elements.Extract, 'hive')

--- a/blaze/expr/datetime.py
+++ b/blaze/expr/datetime.py
@@ -119,7 +119,7 @@ def utcfromtimestamp(expr):
     return UTCFromTimestamp(expr)
 
 
-units = [
+units = (
     'year',
     'month',
     'week',
@@ -129,11 +129,11 @@ units = [
     'second',
     'millisecond',
     'microsecond',
-    'nanosecond'
-]
+    'nanosecond',
+)
 
 
-_unit_aliases = {
+unit_aliases = {
     'y': 'year',
     'w': 'week',
     'd': 'day',
@@ -160,8 +160,8 @@ def normalize_time_unit(s):
     s = s.lower().strip()
     if s in units:
         return s
-    if s in _unit_aliases:
-        return _unit_aliases[s]
+    if s in unit_aliases:
+        return unit_aliases[s]
     if s[-1] == 's':
         return normalize_time_unit(s.rstrip('s'))
 

--- a/docs/source/whatsnew/0.9.1.txt
+++ b/docs/source/whatsnew/0.9.1.txt
@@ -36,8 +36,14 @@ Bug Fixes
 * Fixed a ``blaze-server`` entry point bug regarding an ambiguity between the
   :func:`~blaze.server.spider.spider` function and the
   :module:`~blaze.server.spider` module (:issue:`1385`).
+* Fixed :func:`blaze.expr.datetime.truncate` handling for the sql backend
+  (:issue:`1393`).
 
 Miscellaneous
 ~~~~~~~~~~~~~
 
 * Removed support for Spark 1.3 (:issue:`1386`) based on community consensus.
+* Added :func:`blaze.utils.literal_compile` for converting sqlalchemy
+  expressions into sql strings with bind parameters inlined as sql
+  literals. :func:`blaze.utils.normalize` now accepts a sqlalchemy selectable
+  and uses ``literal_compile`` to convert into a string first (:issue:`1386`).


### PR DESCRIPTION
from the mailing list: https://groups.google.com/a/continuum.io/forum/#!topic/blaze-dev/0LxfZ73pUaQ

DatetimeTruncate was not supported for sql expressions. It was being compiled into an `extract` instead of a `date_trunc`

This also makes `unit_aliases` public for testing and adds some extra test utility functions.