### PR TITLE
ENH: Adds 'ignore_existing' kwarg to create_index

### DIFF
--- a/blaze/compute/pytables.py
+++ b/blaze/compute/pytables.py
@@ -40,7 +40,7 @@ def create_index(t, column, name=None, **kwargs):
     create_index(getattr(t.cols, column), **kwargs)
 
 
-@dispatch(tb.Table, list)
+@dispatch(tb.Table, (list, tuple))
 def create_index(t, columns, name=None, **kwargs):
     if not all(map(partial(hasattr, t.cols), columns)):
         raise ValueError('table %s does not have all passed in columns %s' %

--- a/blaze/sql.py
+++ b/blaze/sql.py
@@ -1,23 +1,39 @@
 from __future__ import absolute_import, division, print_function
 
-from .compatibility import basestring
-from .dispatch import dispatch
-
 import sqlalchemy as sa
 
+from .compatibility import basestring
+from .dispatch import dispatch
 
 __all__ = ()
 
 
+# sqlite raises OperationalError but postgres raises ProgrammingError
+# thanks fam
+_errors = sa.exc.ProgrammingError, sa.exc.OperationalError
+
+
 @dispatch(sa.Table, basestring)
-def create_index(s, column, name=None, unique=False):
+def create_index(s, column, name=None, unique=False, ignore_existing=False):
     if name is None:
         raise ValueError('SQL indexes must have a name')
-    sa.Index(name, s.c[column], unique=unique).create(s.bind)
+    try:
+        sa.Index(name, s.c[column], unique=unique).create(s.bind)
+    except _errors:
+        if not ignore_existing:
+            raise
 
 
-@dispatch(sa.Table, list)
-def create_index(s, columns, name=None, unique=False):
+@dispatch(sa.Table, (list, tuple))
+def create_index(s, columns, name=None, unique=False, ignore_existing=False):
     if name is None:
         raise ValueError('SQL indexes must have a name')
-    sa.Index(name, *(s.c[c] for c in columns), unique=unique).create(s.bind)
+    try:
+        sa.Index(
+            name,
+            *(s.c[c] for c in columns),
+            unique=unique
+        ).create(s.bind)
+    except _errors:
+        if not ignore_existing:
+            raise


### PR DESCRIPTION
Allows users to optionally ignore existing indicies.

This also allows people to pass a tuple of column names instead of a list.