### PR TITLE
BUG: revert a regression in the sql backend

### DIFF
--- a/blaze/compute/tests/test_sql_compute.py
+++ b/blaze/compute/tests/test_sql_compute.py
@@ -2004,6 +2004,10 @@ def test_datetime_trunc_aliases(alias, unit):
     )
 
 
+@pytest.mark.xfail(
+    raises=AssertionError,
+    reason="We don't currently handle the inner select",
+)
 def test_inner_select_with_filter():
     ds = 'var * {a: float32}'
     db = resource('sqlite:///:memory:::s', dshape=ds)

--- a/docs/source/whatsnew/0.9.1.txt
+++ b/docs/source/whatsnew/0.9.1.txt
@@ -50,15 +50,9 @@ Bug Fixes
   the ``_args``. This fixes a case that caused objects that hashed the same to
   not compare equal when somewhere in the tree of ``_args`` was a non hashable
   structure (:issue:`1387`).
-* Fix :class:`~blaze.expr.BinOp`, :class:`~blaze.expr.Pow`, and
-  :class:`~blaze.expr.BinaryMath` handling for selects with a single column and
-  some extra information like a filter or limit. This fixes a bug where things
-  like ``s[s.a == s.a[s.a == 1]].a`` would turn into ``s[s.a == s.a].a`` because
-  we would pull the inner column out of the ``s[s.a == 1]`` and lose the filter
-  (:issue:`1396`).
 * Fixed a type issue where ``datetime - datetime :: datetime`` instead of
   ``timedelta`` (:issue:`1382`).
-* Fixed a bug that prevented :func:`~blaze.expr.expressions.coerce` to fail when
+* Fixed a bug that caused :func:`~blaze.expr.expressions.coerce` to fail when
   computing against ``ColumnElement``\s. This would break ``coerce`` for many
   sql operations (:issue:`1382`).
 * Fixed reductions over ``timedelta`` returning ``float`` (:issue:`1382`).


### PR DESCRIPTION
Leaves the test marked xfail so that we can fix this later.

pr that introduced the regression: #1396