### PR TITLE
BUG: fix the weakkeydict key errors

### DIFF
--- a/blaze/expr/expressions.py
+++ b/blaze/expr/expressions.py
@@ -12,16 +12,12 @@ import toolz
 from toolz import concat, memoize, partial, first
 from toolz.curried import map, filter
 
-from datashape import dshape, DataShape, Record, Var, Mono, Fixed
-from datashape.predicates import isscalar, iscollection, isboolean, isrecord
-
-from ..compatibility import _strtypes, builtins, boundmethod
 from ..compatibility import _strtypes, builtins, boundmethod, PY2
 from .core import Node, subs, common_subexpression, path
 from .method_dispatch import select_functions
 from ..dispatch import dispatch
 from .utils import hashable_index, replace_slices
-from ..utils import weakmemoize
+from ..utils import attribute
 
 
 __all__ = [
@@ -142,8 +138,7 @@ class Expr(Node):
     def _project(self, key):
         return projection(self, key)
 
-    @property
-    @weakmemoize
+    @attribute
     def schema(self):
         try:
             m = self._schema
@@ -152,12 +147,13 @@ class Expr(Node):
         else:
             return m()
 
-        return datashape.dshape(self.dshape.measure)
+        self.schema = schema = datashape.dshape(self.dshape.measure)
+        return schema
 
-    @property
-    @weakmemoize
+    @attribute
     def dshape(self):
-        return self._dshape()
+        self.dshape = dshape = self._dshape()
+        return dshape
 
     @property
     def fields(self):

--- a/blaze/utils.py
+++ b/blaze/utils.py
@@ -5,14 +5,12 @@ from collections import Iterator
 from itertools import islice
 import os
 import re
-from weakref import WeakKeyDictionary
 
 try:
     from cytoolz import nth, unique, concat, first, drop
 except ImportError:
     from toolz import nth, unique, concat, first, drop
 
-from toolz import memoize
 import numpy as np
 # these are used throughout blaze, don't remove them
 from odo.utils import tmpfile, filetext, filetexts, raises, keywords, ignoring
@@ -269,23 +267,6 @@ def literal_compile(s):
     return str(s.compile(compile_kwargs={'literal_binds': True}))
 
 
-def weakmemoize(f):
-    """Memoize ``f`` with a ``WeakKeyDictionary`` to allow the arguments
-    to be garbage collected.
-
-    Parameters
-    ----------
-    f : callable
-        The function to memoize.
-
-    Returns
-    -------
-    g : callable
-        ``f`` with weak memoiza
-    """
-    return memoize(f, cache=WeakKeyDictionary())
-
-
 def ordered_intersect(*sets):
     """Set intersection of two sequences that preserves order.
 
@@ -310,3 +291,22 @@ def ordered_intersect(*sets):
     """
     common = frozenset.intersection(*map(frozenset, sets))
     return (x for x in unique(concat(sets)) if x in common)
+
+
+class attribute(object):
+    """An attribute that can be overridden by instances.
+    This is like a non data descriptor property.
+
+    Parameters
+    ----------
+    f : callable
+        The function to execute.
+    """
+    def __init__(self, f):
+        self._f = f
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+
+        return self._f(instance)

--- a/docs/source/whatsnew/0.9.1.txt
+++ b/docs/source/whatsnew/0.9.1.txt
@@ -58,6 +58,8 @@ Bug Fixes
 * Fixed reductions over ``timedelta`` returning ``float`` (:issue:`1382`).
 * Fixed interactive repr for ``timedelta`` not coercing to ``timedelta``
   objects (:issue:`1382`).
+* Fixed weakkeydict cache failures that were causing ``.dshape`` lookups to fail
+  sometimes (:issue:`1399`).
 
 Miscellaneous
 ~~~~~~~~~~~~~


### PR DESCRIPTION
I have gotten a bunch of magical mysterious weakkeydict errors. This just uses a non data descriptor instead and replaces the `dshape` attribute on instance to get the same caching. This removes any strange cache issues and should be faster.

This change is taken from: #1348 but this particular bug is causing me a lot of problems so I am submitting it as its own change. 