### PR TITLE
coalesce and cast

### DIFF
--- a/blaze/__init__.py
+++ b/blaze/__init__.py
@@ -17,12 +17,44 @@ halt_ordering()  # Turn off multipledispatch ordering
 from datashape import dshape, discover
 from .utils import ignoring
 import warnings
-from .expr import (Symbol, symbol, ndim, shape)
-from .expr import (by, count, count_values, distinct, head, join, label, like,
-                   mean, merge, nunique, relabel, sample, selection, sort,
-                   summary, transform, var)
-from .expr import (date, datetime, day, hour, microsecond, millisecond, month,
-                   second, time, year)
+from .expr import (
+    Symbol,
+    TableSymbol,
+    by,
+    cast,
+    coalesce,
+    count,
+    count_values,
+    date,
+    datetime,
+    day,
+    distinct,
+    distinct, head,
+    head,
+    hour,
+    join,
+    label,
+    like,
+    mean,
+    merge,
+    microsecond,
+    millisecond,
+    month,
+    ndim,
+    nunique,
+    relabel,
+    sample,
+    second,
+    selection,
+    shape,
+    sort,
+    summary,
+    symbol,
+    time,
+    transform,
+    var,
+    year,
+)
 from .expr.arrays import (tensordot, transpose)
 from .expr.functions import *
 from .index import create_index

--- a/blaze/__init__.py
+++ b/blaze/__init__.py
@@ -19,7 +19,6 @@ from .utils import ignoring
 import warnings
 from .expr import (
     Symbol,
-    TableSymbol,
     by,
     cast,
     coalesce,

--- a/blaze/compute/core.py
+++ b/blaze/compute/core.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 from collections import defaultdict, Iterator
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 import itertools
 import numbers
 import warnings
@@ -13,14 +13,14 @@ import pandas as pd
 from odo import odo
 
 from ..compatibility import basestring
-from ..expr import Expr, Field, Symbol, symbol, Join
+from ..expr import Expr, Field, Symbol, symbol, Join, Cast
 from ..dispatch import dispatch
 from ..interactive import coerce_core, into
 
 
 __all__ = ['compute', 'compute_up']
 
-base = numbers.Number, basestring, date, datetime
+base = numbers.Number, basestring, date, datetime, timedelta, type(None)
 
 
 @dispatch(Expr, object)
@@ -46,6 +46,13 @@ def compute_up(a, b, **kwargs):
     raise NotImplementedError("Blaze does not know how to compute "
                               "expression of type `%s` on data of type `%s`"
                               % (type(a).__name__, type(b).__name__))
+
+
+@dispatch(Cast, object)
+def compute_up(c, b, **kwargs):
+    # cast only works on the expression system and does not affect the
+    # computation
+    return b
 
 
 @dispatch(base)
@@ -196,8 +203,9 @@ def top_then_bottom_then_top_again_etc(expr, scope, **kwargs):
     # 4. Repeat
     if expr.isidentical(expr3):
         raise NotImplementedError("Don't know how to compute:\n"
+                                  "type(expr): %s\n"
                                   "expr: %s\n"
-                                  "data: %s" % (expr3, scope4))
+                                  "data: %s" % (type(expr3), expr3, scope4))
     else:
         return top_then_bottom_then_top_again_etc(expr3, scope4, **kwargs)
 

--- a/blaze/compute/tests/test_optimize_compute.py
+++ b/blaze/compute/tests/test_optimize_compute.py
@@ -1,12 +1,14 @@
-from blaze.expr import Expr, symbol
-from blaze.dispatch import dispatch
+from blaze.expr import Expr, symbol, Cast
+from blaze.compute import compute_up
 from blaze import compute
+
 
 class Foo(object):
     def __init__(self, data):
         self.data = data
 
-@dispatch(Expr, Foo)
+
+@compute_up.register((Expr, Cast), Foo)
 def compute_up(expr, data, **kwargs):
     return data
 

--- a/blaze/compute/tests/test_postgresql_compute.py
+++ b/blaze/compute/tests/test_postgresql_compute.py
@@ -13,8 +13,26 @@ import pandas as pd
 
 import pandas.util.testing as tm
 
-from blaze import (atan2, by, compute, concat, cos, data, greatest, join,
-                   least, radians, sin, sqrt, symbol, transform)
+from datashape import dshape
+from odo import odo, drop, discover
+from odo.utils import tmpfile
+from blaze import (
+    data,
+    atan2,
+    by,
+    coalesce,
+    compute,
+    concat,
+    cos,
+    greatest,
+    join,
+    least,
+    radians,
+    sin,
+    sqrt,
+    symbol,
+    transform,
+)
 from blaze.interactive import iscorescalar
 from blaze.utils import example, normalize
 
@@ -593,7 +611,6 @@ def test_sample(sql):
     s2 = odo(result2, pd.DataFrame)
     assert len(s) == len(s2)
 
-
 @pytest.fixture
 def gl_data(sql_two_tables):
     u_data, t_data = sql_two_tables
@@ -609,3 +626,15 @@ def test_greatest(gl_data):
 def test_least(gl_data):
     u, t = gl_data
     assert odo(least(u.a.max(), t.a.max()), int) == 1
+
+
+def test_coalesce(sqla):
+    t = symbol('t', discover(sqla))
+    assert (
+        odo(compute(coalesce(t.B, -1), {t: sqla}), list) ==
+        [(1,), (1,), (-1,)]
+    )
+    assert (
+        odo(compute(coalesce(t.A, 'z'), {t: sqla}), list) ==
+        [('a',), ('z',), ('c',)]
+    )

--- a/blaze/compute/tests/test_postgresql_compute.py
+++ b/blaze/compute/tests/test_postgresql_compute.py
@@ -631,10 +631,10 @@ def test_least(gl_data):
 def test_coalesce(sqla):
     t = symbol('t', discover(sqla))
     assert (
-        odo(compute(coalesce(t.B, -1), {t: sqla}), list) ==
+        compute(coalesce(t.B, -1), {t: sqla}, return_type=list) ==
         [(1,), (1,), (-1,)]
     )
     assert (
-        odo(compute(coalesce(t.A, 'z'), {t: sqla}), list) ==
+        compute(coalesce(t.A, 'z'), {t: sqla}, return_type=list) ==
         [('a',), ('z',), ('c',)]
     )

--- a/blaze/compute/tests/test_sql_compute.py
+++ b/blaze/compute/tests/test_sql_compute.py
@@ -2070,7 +2070,7 @@ def test_greatest(op):
 
 def test_coalesce():
     ds = 'var * {a: ?int32}'
-    db = resource('sqlite:///m:memory:::s', dshape=ds)
+    db = resource('sqlite:///:memory:::s', dshape=ds)
     s = symbol('s', ds)
     t = symbol('s', 'int32')
 

--- a/blaze/expr/arithmetic.py
+++ b/blaze/expr/arithmetic.py
@@ -17,14 +17,14 @@ from datashape import (
     promote,
     timedelta_,
     unsigned,
-    var,
 )
 from datashape.predicates import isscalar, isboolean, isnumeric, isdatelike
 from dateutil.parser import parse as dt_parse
 
 
 from .core import parenthesize, eval_str
-from .expressions import Expr, shape, ElemWise
+from .expressions import Expr, shape, ElemWise, binop_inputs, binop_name
+from .utils import maxshape
 from ..dispatch import dispatch
 from ..compatibility import _strtypes
 
@@ -76,64 +76,12 @@ class BinOp(ElemWise):
         return DataShape(*(maxshape([shape(self.lhs), shape(self.rhs)]) +
                            (self._dtype,)))
 
-    @property
-    def _name(self):
-        if not isscalar(self.dshape.measure):
-            return None
-        l = getattr(self.lhs, '_name', None)
-        r = getattr(self.rhs, '_name', None)
-        if l is not None and r is None:
-            return l
-        elif r is not None and l is None:
-            return r
-        elif l == r:
-            return l
-        else:
-            return None
+    _name = property(binop_name)
+
 
     @property
     def _inputs(self):
-        result = []
-        if isinstance(self.lhs, Expr):
-            result.append(self.lhs)
-        if isinstance(self.rhs, Expr):
-            result.append(self.rhs)
-        return tuple(result)
-
-
-def maxvar(L):
-    """
-
-    >>> maxvar([1, 2, var])
-    Var()
-
-    >>> maxvar([1, 2, 3])
-    3
-    """
-    if var in L:
-        return var
-    else:
-        return max(L)
-
-
-def maxshape(shapes):
-    """
-
-    >>> maxshape([(10, 1), (1, 10), ()])
-    (10, 10)
-
-    >>> maxshape([(4, 5), (5,)])
-    (4, 5)
-    """
-    shapes = [shape for shape in shapes if shape]
-    if not shapes:
-        return ()
-    ndim = max(map(len, shapes))
-    shapes = [(1,) * (ndim - len(shape)) + shape for shape in shapes]
-    for dims in zip(*shapes):
-        if len(set(dims) - set([1])) >= 2:
-            raise ValueError("Shapes don't align, %s" % str(dims))
-    return tuple(map(maxvar, zip(*shapes)))
+        return tuple(binop_inputs(self))
 
 
 class UnaryOp(ElemWise):

--- a/blaze/expr/core.py
+++ b/blaze/expr/core.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import datetime
 import numbers
 import inspect
 
@@ -18,7 +19,7 @@ from ..utils import ordered_intersect
 __all__ = ['Node', 'path', 'common_subexpression', 'eval_str']
 
 
-base = (numbers.Number,) + _strtypes
+base = (numbers.Number,) + _strtypes + (datetime.datetime, datetime.timedelta)
 
 
 def isidentical(a, b):

--- a/blaze/expr/expressions.py
+++ b/blaze/expr/expressions.py
@@ -4,7 +4,17 @@ from keyword import iskeyword
 import re
 
 import datashape
-from datashape import dshape, DataShape, Record, Var, Mono, Fixed
+from datashape import (
+    dshape,
+    DataShape,
+    Record,
+    Var,
+    Mono,
+    Fixed,
+    promote,
+    Option,
+    Null,
+)
 from datashape.predicates import isscalar, iscollection, isboolean, isrecord
 import numpy as np
 from odo.utils import copydoc
@@ -16,12 +26,14 @@ from ..compatibility import _strtypes, builtins, boundmethod, PY2
 from .core import Node, subs, common_subexpression, path
 from .method_dispatch import select_functions
 from ..dispatch import dispatch
-from .utils import hashable_index, replace_slices
+from .utils import hashable_index, replace_slices, maxshape
 from ..utils import attribute
 
 
 __all__ = [
     'Apply',
+    'Cast',
+    'Coalesce',
     'Coerce',
     'ElemWise',
     'Expr',
@@ -35,6 +47,8 @@ __all__ = [
     'Slice',
     'Symbol',
     'apply',
+    'cast',
+    'coalesce',
     'coerce',
     'discover',
     'label',
@@ -790,6 +804,92 @@ def coerce(expr, to):
     return Coerce(expr, dshape(to) if isinstance(to, _strtypes) else to)
 
 
+class Cast(Expr):
+    """Cast an expression to a different type.
+
+    This is only an expression time operation.
+    """
+    __slots__ = '_hash', '_child', 'to'
+
+    def _dshape(self):
+        return self.to
+
+    def __str__(self):
+        return 'cast(%s, to=%r)' % (self._child, str(self.to))
+
+
+@copydoc(Cast)
+def cast(expr, to):
+    return Cast(expr, dshape(to) if isinstance(to, _strtypes) else to)
+
+
+Expr.cast = cast  # method of all exprs
+
+
+def binop_name(expr):
+    if not isscalar(expr.dshape.measure):
+        return None
+    l = getattr(expr.lhs, '_name', None)
+    r = getattr(expr.rhs, '_name', None)
+    if bool(l) ^ bool(r):
+        return l or r
+    elif l == r:
+        return l
+
+    return None
+
+
+def binop_inputs(expr):
+    if isinstance(expr.lhs, Expr):
+        yield expr.lhs
+    if isinstance(expr.rhs, Expr):
+        yield expr.rhs
+
+
+class Coalesce(Expr):
+    """SQL like coalesce.
+
+    coalesce(a, b) = {
+        a if a is not NULL
+        b otherwise
+    }
+    """
+    __slots__ = '_hash', 'lhs', 'rhs', 'dshape'
+    __inputs__ = 'lhs', 'rhs'
+
+    def __str__(self):
+        return 'coalesce(%s, %s)' % (self.lhs, self.rhs)
+
+    _name = property(binop_name)
+
+    @property
+    def _inputs(self):
+        return tuple(binop_inputs(self))
+
+
+@copydoc(Coalesce)
+def coalesce(a, b):
+    a_dshape = discover(a)
+    a_measure = a_dshape.measure
+    isoption = isinstance(a_measure, Option)
+    if isoption:
+        a_measure = a_measure.ty
+    isnull = isinstance(a_measure, Null)
+    if isnull:
+        # a is always null, this is just b
+        return b
+
+    if not isoption:
+        # a is not an option, this is just a
+        return a
+
+    b_dshape = discover(b)
+    return Coalesce(a, b, DataShape(*(
+        maxshape((a_dshape.shape, b_dshape.shape)) +
+        (promote(a_measure, b_dshape.measure),)
+    )))
+
+
 dshape_method_list = list()
 schema_method_list = list()
 method_properties = set()
@@ -845,6 +945,7 @@ dshape_method_list.extend([
 schema_method_list.extend([
     (isscalar, set([label, relabel, coerce])),
     (isrecord, set([relabel])),
+    (lambda ds: isinstance(ds, Option), {coalesce}),
 ])
 
 method_properties.update([shape, ndim])

--- a/blaze/expr/expressions.py
+++ b/blaze/expr/expressions.py
@@ -808,6 +808,21 @@ class Cast(Expr):
     """Cast an expression to a different type.
 
     This is only an expression time operation.
+
+    Examples
+    --------
+    >>> s = symbol('s', '?int64')
+    >>> s.cast('?int32').dshape
+    dshape("?int32")
+
+    # Cast to correct mislabeled optionals
+    >>> s.cast('int64').dshape
+    dshape("int64")
+
+    # Cast to give concrete dimension length
+    >>> t = symbol('t', 'var * float32')
+    >>> t.cast('10 * float32').dshape
+    >>> dshape("10 * float32")
     """
     __slots__ = '_hash', '_child', 'to'
 
@@ -853,6 +868,17 @@ class Coalesce(Expr):
         a if a is not NULL
         b otherwise
     }
+
+    Examples
+    --------
+    >>> coalesce(1, 2)
+    1
+    >>> coalesce(1, None)
+    1
+    >>> coalesce(None, 2)
+    2
+    >>> coalesce(None, None) is None
+    True
     """
     __slots__ = '_hash', 'lhs', 'rhs', 'dshape'
     __inputs__ = 'lhs', 'rhs'

--- a/blaze/expr/expressions.py
+++ b/blaze/expr/expressions.py
@@ -170,13 +170,16 @@ class Expr(Node):
 
     @property
     def fields(self):
-        if isinstance(self.dshape.measure, Record):
-            return self.dshape.measure.names
-        elif isinstance(self.dshape.measure, datashape.Map):
+        measure = self.dshape.measure
+        if isinstance(self.dshape.measure, Option):
+            measure = measure.ty
+        if isinstance(measure, Record):
+            return measure.names
+        elif isinstance(measure, datashape.Map):
             if not isrecord(self.dshape.measure.value):
                 raise TypeError('Foreign key must reference a '
                                 'Record datashape')
-            return self.dshape.measure.value.names
+            return measure.value.names
         name = getattr(self, '_name', None)
         if name is not None:
             return [self._name]

--- a/blaze/expr/expressions.py
+++ b/blaze/expr/expressions.py
@@ -825,7 +825,7 @@ class Cast(Expr):
     # Cast to give concrete dimension length
     >>> t = symbol('t', 'var * float32')
     >>> t.cast('10 * float32').dshape
-    >>> dshape("10 * float32")
+    dshape("10 * float32")
     """
     __slots__ = '_hash', '_child', 'to'
 

--- a/blaze/expr/math.py
+++ b/blaze/expr/math.py
@@ -4,6 +4,7 @@ from datashape import Option, real, int_, bool_, isreal, isnumeric
 
 from .arithmetic import UnaryOp, BinOp, Arithmetic
 from .expressions import schema_method_list
+from ..compatibility import builtins
 
 
 # Here follows a large number of unary operators.  These were selected by
@@ -79,11 +80,19 @@ for name in _binary_math_names:
 class greatest(Arithmetic):
     __slots__ = '_hash', 'lhs', 'rhs'
     __inputs__ = 'lhs', 'rhs'
+    op = builtins.max
+
+    def __str__(self):
+        return 'greatest(%s, %s)' % (self.lhs, self.rhs)
 
 
 class least(Arithmetic):
     __slots__ = '_hash', 'lhs', 'rhs'
     __inputs__ = 'lhs', 'rhs'
+    op = builtins.min
+
+    def __str__(self):
+        return 'least(%s, %s)' % (self.lhs, self.rhs)
 
 
 _unary_integer_math = (

--- a/blaze/expr/reductions.py
+++ b/blaze/expr/reductions.py
@@ -9,9 +9,8 @@ from odo.utils import copydoc
 import toolz
 
 from .core import common_subexpression
-from .expressions import Expr, ndim
+from .expressions import Expr, ndim, dshape_method_list, method_properties
 from .strings import isstring
-from .expressions import dshape_method_list, method_properties
 
 
 class Reduction(Expr):

--- a/blaze/expr/tests/test_arithmetic.py
+++ b/blaze/expr/tests/test_arithmetic.py
@@ -102,9 +102,26 @@ def test_arith_ops_promote_dtype():
 
 
 def test_str_arith():
-    assert isinstance(cs * 1, Repeat)
-    assert isinstance(cs % cs, Interp)
-    assert isinstance(cs % 'a', Interp)
+    rep = cs * 1
+    assert isinstance(rep, Repeat)
+    assert rep.lhs.isidentical(cs)
+    assert rep.rhs == 1
+
+    with pytest.raises(TypeError):
+        cs * 1.5
+
+    with pytest.raises(TypeError):
+        cs * 'a'
+
+    interp = cs % cs
+    assert isinstance(interp, Interp)
+    assert interp.lhs.isidentical(cs)
+    assert interp.rhs.isidentical(cs)
+
+    interp_lit = cs % 'a'
+    assert isinstance(interp_lit, Interp)
+    assert interp_lit.lhs.isidentical(cs)
+    assert interp_lit.rhs == 'a'
 
     with pytest.raises(Exception):
         cs / 1

--- a/blaze/expr/utils.py
+++ b/blaze/expr/utils.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
+from datashape import var
+
+
 class _slice(object):
     """ A hashable slice object
 
@@ -80,3 +83,38 @@ def replace_slices(index):
     elif isinstance(index, tuple):
         return tuple(map(replace_slices, index))
     return index
+
+
+def maxvar(L):
+    """
+
+    >>> maxvar([1, 2, var])
+    Var()
+
+    >>> maxvar([1, 2, 3])
+    3
+    """
+    if var in L:
+        return var
+    else:
+        return max(L)
+
+
+def maxshape(shapes):
+    """
+
+    >>> maxshape([(10, 1), (1, 10), ()])
+    (10, 10)
+
+    >>> maxshape([(4, 5), (5,)])
+    (4, 5)
+    """
+    shapes = [shape for shape in shapes if shape]
+    if not shapes:
+        return ()
+    ndim = max(map(len, shapes))
+    shapes = [(1,) * (ndim - len(shape)) + shape for shape in shapes]
+    for dims in zip(*shapes):
+        if len(set(dims) - set([1])) >= 2:
+            raise ValueError("Shapes don't align, %s" % str(dims))
+    return tuple(map(maxvar, zip(*shapes)))

--- a/blaze/utils.py
+++ b/blaze/utils.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import datetime
 from collections import Iterator
-from itertools import islice
+from itertools import islice, product
 import os
 import re
 
@@ -363,3 +363,36 @@ class attribute(object):
             return self
 
         return self._f(instance)
+
+
+def parameter_space(*args):
+    """Unpack a sequence of positional parameter spaces into the product of each
+    space.
+
+    Parameters
+    ----------
+    *args
+        The parameters spaces to create a product of.
+
+    Returns
+    -------
+    param_space : tuple[tuple]
+        The product of each of the spaces.
+
+    Examples
+    --------
+    # trivial case
+    >>> parameter_space(0, 1, 2)
+    ((0, 1, 2),)
+
+    # two 2-tuples
+    >>> parameter_space((0, 1), (2, 3))
+    ((0, 2), (0, 3), (1, 2), (1, 3))
+
+    Notes
+    -----
+    This is a convenience for passing to :func:`pytest.mark.parameterized`
+    """
+    return tuple(product(*(
+        arg if isinstance(arg, tuple) else (arg,) for arg in args
+    )))

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -30,6 +30,8 @@ Expressions
    Map
    Apply
    Coerce
+   Coalesce
+   Cast
 
 .. currentmodule:: blaze.expr.collections
 

--- a/docs/source/whatsnew/0.10.0.txt
+++ b/docs/source/whatsnew/0.10.0.txt
@@ -15,12 +15,21 @@ New Expressions
   the result is missing. For example: ``coalesce(1, 2) == 1``,
   ``coalesce(None, 1)`` == 1, and ``coalesce(None, None) == None``.
   This is inspired by the sql function of the same name (:issue:`1409`).
-* Adds :func:`~blaze.expr.expressions.cast` expression as a type level function
-  for reinterpreting an expression as another dshape. This is based on C++
-  ``reinterpret_cast``, or just normal C casts. For example:
+* Adds :func:`~blaze.expr.expressions.cast` expression to reinterpret an
+  expression's dshape. This is based on C++ ``reinterpret_cast``, or just normal
+  C casts. For example:
   ``symbol('s', 'int32').cast('uint32').dshape == dshape('uint32')``. This
-  expression is the identity function at runtime but allows users to alter the
-  types of expressions where needed (:issue:`1409`).
+  expression has no affect on the computation, it merely tells blaze to treat
+  the result of the expression as the new dshape. The compute definition for
+  ``cast`` is simply:
+
+  .. code-block:: python
+
+     @dispatch(Cast, object)
+     def compute_up(expr, data, **kwargs):
+         return data
+
+  (:issue:`1409`).
 
 Improved Expressions
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/whatsnew/0.10.0.txt
+++ b/docs/source/whatsnew/0.10.0.txt
@@ -10,6 +10,17 @@ New Expressions
 * The ``sample`` expression allows random sampling of rows to facilitate
   interactive data exploration (:issue:`1410`).  It is implemented for the
   Pandas, Dask, SQL, and Python backends.
+* Adds :func:`~blaze.expr.expressions.coalesce` expression which takes two
+  arguments and returns the first non missing value. If both are missing then
+  the result is missing. For example: ``coalesce(1, 2) == 1``,
+  ``coalesce(None, 1)`` == 1, and ``coalesce(None, None) == None``.
+  This is inspired by the sql function of the same name (:issue:`1409`).
+* Adds :func:`~blaze.expr.expressions.cast` expression as a type level function
+  for reinterpreting an expression as another dshape. This is based on C++
+  ``reinterpret_cast``, or just normal C casts. For example:
+  ``symbol('s', 'int32').cast('uint32').dshape == dshape('uint32')``. This
+  expression is the identity function at runtime but allows users to alter the
+  types of expressions where needed (:issue:`1409`).
 
 Improved Expressions
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
`cast` is needed when blaze is incorrect about the types of an expression. For example, the case I opened earlier about reductions of `var * A` being typed `A` instead of `?A` when the collection could be empty. To make it easy to work around this we should be able to explicitly overwrite the type.

`coalesce` is useful for a lot of queries.