### PR TITLE
WIP: changed from_yaml to use pathes relative to yaml file, not relative to CWD

### DIFF
--- a/blaze/server/spider.py
+++ b/blaze/server/spider.py
@@ -7,7 +7,6 @@ import sys
 import argparse
 import importlib
 
-import toolz
 import yaml
 
 from odo import resource
@@ -105,9 +104,17 @@ def from_yaml(path, ignore=(ValueError, NotImplementedError), followlinks=True,
     data_spider : Traverse a directory tree for resources
     """
     resources = {}
+    yaml_dir = os.path.split(os.path.abspath(path.name))[0]
     for name, info in yaml.load(path.read()).items():
         try:
             source = info.pop('source')
+
+            # convert relative pathes to absolute relative to yaml file
+            if (not os.path.isabs(source) and
+               not source.startswith('http') and
+               '~' not in source):
+                source = os.path.join(yaml_dir, source)
+
         except KeyError:
             raise ValueError('source key not found for data source named %r' %
                              name)

--- a/blaze/server/spider.py
+++ b/blaze/server/spider.py
@@ -105,6 +105,7 @@ def from_yaml(path, ignore=(ValueError, NotImplementedError), followlinks=True,
     """
     resources = {}
     yaml_dir = os.path.split(os.path.abspath(path.name))[0]
+    owd = os.getcwd()
     for name, info in yaml.load(path.read()).items():
         try:
             source = info.pop('source')
@@ -113,7 +114,16 @@ def from_yaml(path, ignore=(ValueError, NotImplementedError), followlinks=True,
             if (not os.path.isabs(source) and
                not source.startswith('http') and
                '~' not in source):
-                source = os.path.join(yaml_dir, source)
+                os.chdir(yaml_dir)
+                src = os.path.abspath(source)
+                os.chdir(owd)
+
+                # handle 'sqlite:///../path/with/protocol/test.db'
+                if ('://' in source):
+                    protocol = source.split('://')[0]
+                    source = protocol + '://' + src
+
+                source = src
 
         except KeyError:
             raise ValueError('source key not found for data source named %r' %


### PR DESCRIPTION
To help with portability of yaml config files, I've changed `from_yaml` to look relative to the yaml `path.name` instead of the current working directory.  

So my thinking is:
  - if `source` is a relative file path (`../my_csv.csv`), then make it absolute path relative to the yaml config
  - if `source` is a uri (`http://www.google.com`), then let it be...
  - if `source` includes `~`, then let it be and allow `expanduser` to deal with it...
  - if `source` contains a protocol and relative path (`sqlite://../examples/iris/db`) then make it absolute path relative to yaml files.

What other situations should i consider?