### PR TITLE
WIP: add flake8 section to setup.cfg.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,3 @@
-
 # See the docstring in versioneer.py for instructions. Note that you must
 # re-run 'versioneer.py setup' after changing this section, and commit the
 # resulting files.
@@ -11,3 +10,25 @@ versionfile_build = blaze/_version.py
 tag_prefix =
 parentdir_prefix = blaze-
 
+[flake8]
+# References:
+# http://flake8.readthedocs.org/en/latest/config.html
+# http://flake8.readthedocs.org/en/latest/warnings.html#error-codes
+#
+# Style checks turned on:
+#   F - all pyflake errors except F811 due to multipledispatch multiple defines.
+#   E101 - indentation contains mixed spaces and tabs
+#   E111 - indentation is not a multiple of four
+#   E131 - continuation line unaligned for hanging indent
+#   E133 - closing bracket is missing indentation
+#   E501 - line too long (see max-line-length)
+
+# Note: there cannot be spaces after commas here
+exclude = __init__.py,compatibility.py
+select = F4,F812,F82,F831,F841,E101,E111,E501
+ignore = F811,E,W
+max-line-length = 160
+
+# indentation style stuff
+# select = E131,E133
+# hang-closing = 1


### PR DESCRIPTION
For now, this configures flake8 to flag:
- F - all pyflake errors except F811 due to multipledispatch multiple defines.
- E101 - indentation contains mixed spaces and tabs
- E111 - indentation is not a multiple of four
- E501 - line too long (see max-line-length)

It excludes `__init__.py` due to `import *`'s, and `compatibility.py` due to unused imports.

The thinking is that at some point in the future, a `flake8` check is run as part of TravisCI, and we will fail builds based on the above checks.  I'm not ready / willing to take that step until there's agreement on the above checks.
