### PR TITLE
Fix bug in Pandas compute_up() on Broadcast exprs.

### DIFF
--- a/blaze/compute/pandas.py
+++ b/blaze/compute/pandas.py
@@ -91,8 +91,7 @@ def compute_up(t, data, **kwargs):
 
 @dispatch(Broadcast, (DataFrame, DaskDataFrame))
 def compute_up(t, df, **kwargs):
-    d = dict((t._child[c]._expr, df[c]) for c in t._child.fields)
-    return compute(t._expr, d)
+    return compute(t._full_expr, df)
 
 
 @dispatch(Broadcast, Series)

--- a/blaze/compute/tests/test_dask_dataframe.py
+++ b/blaze/compute/tests/test_dask_dataframe.py
@@ -6,7 +6,7 @@ import pandas.util.testing as tm
 
 dd = pytest.importorskip('dask.dataframe')
 
-from blaze import symbol, discover, compute
+from blaze import symbol, discover, compute, broadcast_collect
 from blaze.expr import mean, count, sum, min, max, var, std, summary
 
 
@@ -40,6 +40,12 @@ dfbig = pd.DataFrame([['Alice', 'F', 100, 1],
 
 ddf = dd.from_pandas(df, npartitions=2)
 ddfbig = dd.from_pandas(dfbig, npartitions=2)
+
+
+def test_broadcast():
+    bcast = broadcast_collect(expr=t.amount * t.id)
+    result = compute(bcast, ddf)
+    eq(result, df.amount * df.id)
 
 
 def test_symbol():

--- a/blaze/compute/tests/test_pandas_compute.py
+++ b/blaze/compute/tests/test_pandas_compute.py
@@ -14,7 +14,7 @@ from string import ascii_lowercase
 
 from blaze.compute.core import compute
 from blaze.compute.pandas import pdsort
-from blaze import dshape, discover, transform
+from blaze import dshape, discover, transform, broadcast_collect
 from blaze.expr import symbol, join, by, summary, distinct, shape
 from blaze.expr import (merge, exp, mean, count, nunique, sum, min, max, any,
                         var, std, concat)
@@ -43,6 +43,20 @@ dfbig = DataFrame([['Alice', 'F', 100, 1],
                    ['Drew', 'M', 100, 5],
                    ['Drew', 'M', 200, 5]],
                   columns=['name', 'sex', 'amount', 'id'])
+
+
+def test_series_broadcast():
+    s = Series([1, 2, 3], name='a')
+    t = symbol('t', 'var * {a: int64}')
+    bcast = broadcast_collect(expr=(2 * t.a - t.a**2))
+    result = compute(bcast, s)
+    assert_series_equal(2 * s - s**2, result)
+
+
+def test_frame_broadcast():
+    bcast = broadcast_collect(expr=t.amount * t.id)
+    result = compute(bcast, df)
+    assert_series_equal(df.amount * df.id, result)
 
 
 def test_series_columnwise():

--- a/blaze/compute/tests/test_pandas_compute.py
+++ b/blaze/compute/tests/test_pandas_compute.py
@@ -50,13 +50,13 @@ def test_series_broadcast():
     t = symbol('t', 'var * {a: int64}')
     bcast = broadcast_collect(expr=(2 * t.a - t.a**2))
     result = compute(bcast, s)
-    assert_series_equal(2 * s - s**2, result)
+    assert_series_equal(result, 2 * s - s**2)
 
 
 def test_frame_broadcast():
     bcast = broadcast_collect(expr=t.amount * t.id)
     result = compute(bcast, df)
-    assert_series_equal(df.amount * df.id, result)
+    assert_series_equal(result, df.amount * df.id)
 
 
 def test_series_columnwise():

--- a/docs/source/whatsnew/0.10.0.txt
+++ b/docs/source/whatsnew/0.10.0.txt
@@ -60,7 +60,10 @@ API Changes
 Bug Fixes
 ~~~~~~~~~
 
-None
+* Fixed a bug with Pandas' implementation of ``compute_up`` on
+  :class:`~blaze.expr.broadcast.Broadcast` expressions (:issue:`1442`).  Added
+  tests for Pandas frame and series and dask dataframes on ``Broadcast``
+  expressions.
 
 Miscellaneous
 ~~~~~~~~~~~~~


### PR DESCRIPTION
Adds broadcast tests for Pandas frames / series and Dask dataframes.