### PR TITLE
MAINT: explicitly pass return_type='native' in internal cals to compute

### DIFF
--- a/blaze/compute/bcolz.py
+++ b/blaze/compute/bcolz.py
@@ -104,7 +104,12 @@ def compute_down(expr, data, **kwargs):
     leaf = expr._leaves()[0]
     if all(isinstance(e, Cheap) for e in path(expr, leaf)):
         val = data.value
-        return compute(expr, {leaf: into(Iterator, val)}, **kwargs)
+        return compute(
+            expr,
+            {leaf: into(Iterator, val)},
+            return_type='native',
+            **kwargs
+        )
     else:
         raise MDNotImplementedError()
 
@@ -126,7 +131,7 @@ def compute_up(expr, data, **kwargs):
 
 def compute_chunk(source, chunk, chunk_expr, data_index):
     part = source[data_index]
-    return compute(chunk_expr, {chunk: part})
+    return compute(chunk_expr, {chunk: part}, return_type='native')
 
 
 def get_chunksize(data):
@@ -178,7 +183,7 @@ def compute_down(expr, data, chunksize=None, map=None, **kwargs):
         raise TypeError("Don't know how to concatenate objects of type %r" %
                         type(parts[0]).__name__)
 
-    return compute(agg_expr, {agg: intermediate})
+    return compute(agg_expr, {agg: intermediate}, return_type='native')
 
 
 def _asarray(a):
@@ -193,4 +198,5 @@ def bcolz_mixed(expr, a, b, **kwargs):
     return compute(
         expr,
         dict(zip(expr._leaves(), map(_asarray, (a.value, b.value)))),
+        return_type='native',
     )

--- a/blaze/compute/csv.py
+++ b/blaze/compute/csv.py
@@ -72,7 +72,7 @@ def pre_compute(expr, data, **kwargs):
 
 
 def compute_chunk(chunk, chunk_expr, part):
-    return compute(chunk_expr, {chunk: part})
+    return compute(chunk_expr, {chunk: part}, return_type='native')
 
 
 @dispatch(Expr, pandas.io.parsers.TextFileReader)
@@ -92,4 +92,4 @@ def compute_down(expr, data, map=None, **kwargs):
     elif isinstance(parts[0], (Iterable, Iterator)):
         intermediate = concat(parts)
 
-    return compute(agg_expr, {agg: intermediate})
+    return compute(agg_expr, {agg: intermediate}, return_type='native')

--- a/blaze/compute/h5py.py
+++ b/blaze/compute/h5py.py
@@ -128,7 +128,7 @@ def compute_chunk(source, target, chunk, chunk_expr, parts):
     """ Pull out a part, compute it, insert it into the target """
     source_part, target_part = parts
     part = source[source_part]
-    result = compute(chunk_expr, {chunk: part})
+    result = compute(chunk_expr, {chunk: part}, return_type='native')
     target[target_part] = result
 
 
@@ -190,4 +190,4 @@ def compute_down(expr, data, map=None, **kwargs):
     ))
 
     # Compute on the aggregate
-    return compute(agg_expr, {agg: intermediate})
+    return compute(agg_expr, {agg: intermediate}, return_type='native')

--- a/blaze/compute/python.py
+++ b/blaze/compute/python.py
@@ -536,7 +536,7 @@ def compute_up(t, seq, **kwargs):
     else:
         grouper = rrowfunc(t.grouper, t._child)
         groups = groupby(grouper, seq)
-        d = dict((k, compute(t.apply, {t._child: v}))
+        d = dict((k, compute(t.apply, {t._child: v}, return_type='native'))
                  for k, v in groups.items())
 
     if isscalar(t.grouper.dshape.measure):
@@ -689,11 +689,15 @@ def compute_up(expr, data, **kwargs):
         raise NotImplementedError('Only 1D reductions currently supported')
     if isinstance(data, Iterator):
         datas = itertools.tee(data, len(expr.values))
-        result = tuple(compute(val, {expr._child: data})
-                       for val, data in zip(expr.values, datas))
+        result = tuple(
+            compute(val, {expr._child: data}, return_type='native')
+            for val, data in zip(expr.values, datas)
+        )
     else:
-        result = tuple(compute(val, {expr._child: data})
-                       for val in expr.values)
+        result = tuple(
+            compute(val, {expr._child: data}, return_type='native')
+            for val in expr.values
+        )
 
     if expr.keepdims:
         return (result,)

--- a/blaze/compute/spark.py
+++ b/blaze/compute/spark.py
@@ -200,7 +200,10 @@ def compute_up(t, rdd, **kwargs):
 @dispatch(Summary, RDD)
 def compute_up(t, rdd, **kwargs):
     rdd = rdd.cache()
-    return tuple(compute(value, {t._child: rdd}) for value in t.values)
+    return tuple(
+        compute(value, {t._child: rdd}, return_type='native')
+        for value in t.values
+    )
 
 
 @dispatch(Like, RDD)

--- a/blaze/compute/sparksql.py
+++ b/blaze/compute/sparksql.py
@@ -86,7 +86,7 @@ def compute_down(expr, data, **kwargs):
 
     # compute using sqlalchemy
     scope = dict(zip(new_leaves, map(make_sqlalchemy_table, tables)))
-    query = compute(expr, scope)
+    query = compute(expr, scope, return_type='native')
 
     # interpolate params
     compiled = literalquery(query, dialect=HiveDialect())


### PR DESCRIPTION
Still got warnings after the last change because we used the deprecated default