### PR TITLE
Error checking when adding to blaze server.

### DIFF
--- a/blaze/server/tests/test_server.py
+++ b/blaze/server/tests/test_server.py
@@ -563,11 +563,21 @@ def test_add_data_twice_error(temp_server, serial):
     temp_server.post('/add',
                       headers=mimetype(serial),
                       data=payload)
+
     # Try to add to existing 'iris'
     resp = temp_server.post('/add',
                             headers=mimetype(serial),
                             data=payload)
     assert resp.status_code == RC.CONFLICT
+
+    # Verify the server still serves the original 'iris'.
+    ds = datashape.dshape(temp_server.get('/datashape').data.decode('utf-8'))
+    t = symbol('t', ds)
+    query = {'expr': to_tree(t.iris)}
+    resp = temp_server.post('/compute',
+                            data=serial.dumps(query),
+                            headers=mimetype(serial))
+    assert resp.status_code == RC.OK
 
 
 @pytest.mark.parametrize('serial', all_formats)

--- a/docs/source/whatsnew/0.10.0.txt
+++ b/docs/source/whatsnew/0.10.0.txt
@@ -95,6 +95,11 @@ Bug Fixes
   expressions.
 * Fixed a bug with :class:`~blaze.expr.collections.Sample` on SQL backends
   (:issue:`1452` :issue:`1423` :issue:`1424` :issue:`1425`).
+* Fixed several bugs relating to adding new datasets to blaze server instances
+  (:issue:`1459`).  Blaze server will make a best effort to ensure that the
+  added dataset is valid and loadable; if not, it will return appropriate HTTP
+  status codes.
+
 
 Miscellaneous
 ~~~~~~~~~~~~~


### PR DESCRIPTION
Does basic error checking when adding a new data set to a blaze server (`/add` endpoint):
* prevent adding a dataset when there's a name collision with existing dataset;
* check that the data is `discover`able to verify the data is loadable and queryable;
* capture any other exception and return appropriate error code and traceback string.

I also reformatted the indentation in other tests for consistency.