### PR TITLE
String broadcastables

### DIFF
--- a/blaze/compute/pandas.py
+++ b/blaze/compute/pandas.py
@@ -286,6 +286,8 @@ def compute_up(expr, data, **kwargs):
 
 string_func_names = {
     'strlen': 'len',
+    'strupper': 'upper',
+    'strlower': 'lower',
 }
 
 

--- a/blaze/compute/pandas.py
+++ b/blaze/compute/pandas.py
@@ -284,11 +284,10 @@ def compute_up(expr, data, **kwargs):
     return compute_up(expr._child.distinct().count(), data, **kwargs)
 
 
-string_func_names = {
-    'strlen': 'len',
-    'strupper': 'upper',
-    'strlower': 'lower',
-}
+string_func_names = {'str_len': 'len',
+                     'strlen': 'len',
+                     'str_upper': 'upper',
+                     'str_lower': 'lower'}
 
 
 @dispatch(UnaryStringFunction, Series)

--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -88,6 +88,7 @@ from ..expr import (
     notnull,
     nunique,
     std,
+    str_len,
     strlen,
     var,
 )
@@ -1182,6 +1183,8 @@ def compute_up(t, s, **kwargs):
 
 string_func_names = {
     # <blaze function name>: <SQL function name>
+    'str_upper': 'upper',
+    'str_lower': 'lower',
 }
 
 
@@ -1196,7 +1199,7 @@ def compile_char_length_on_hive(element, compiler, **kwargs):
     return compiler.visit_function(element, **kwargs)
 
 
-@dispatch(strlen, ColumnElement)
+@dispatch((strlen, str_len), ColumnElement)
 def compute_up(expr, data, **kwargs):
     return sa.sql.functions.char_length(data).label(expr._name)
 

--- a/blaze/compute/tests/test_pandas_compute.py
+++ b/blaze/compute/tests/test_pandas_compute.py
@@ -659,22 +659,22 @@ def test_like():
     tm.assert_frame_equal(result, expected)
 
 
-def test_strlen():
-    expr = t.name.strlen()
+def test_str_len():
+    expr = t.name.str_len()
     expected = pd.Series([5, 3, 5], name='name')
     result = compute(expr, df).reset_index(drop=True)
     assert_series_equal(expected, result)
 
 
-def test_strupper():
-    expr = t.name.strupper()
+def test_str_upper():
+    expr = t.name.str_upper()
     expected = pd.Series(['ALICE', 'BOB', 'ALICE'], name='name')
     result = compute(expr, df).reset_index(drop=True)
     assert_series_equal(expected, result)
 
 
-def test_strlower():
-    expr = t.name.strlower()
+def test_str_lower():
+    expr = t.name.str_lower()
     expected = pd.Series(['alice', 'bob', 'alice'], name='name')
     result = compute(expr, df).reset_index(drop=True)
     assert_series_equal(expected, result)

--- a/blaze/compute/tests/test_pandas_compute.py
+++ b/blaze/compute/tests/test_pandas_compute.py
@@ -666,6 +666,21 @@ def test_strlen():
     assert_series_equal(expected, result)
 
 
+def test_strupper():
+    expr = t.name.strupper()
+    expected = pd.Series(['ALICE', 'BOB', 'ALICE'], name='name')
+    result = compute(expr, df).reset_index(drop=True)
+    assert_series_equal(expected, result)
+
+
+def test_strlower():
+    expr = t.name.strlower()
+    expected = pd.Series(['alice', 'bob', 'alice'], name='name')
+    result = compute(expr, df).reset_index(drop=True)
+    assert_series_equal(expected, result)
+
+
+
 def test_rowwise_by():
     f = lambda _, id, name: id + len(name)
     expr = by(t.map(f, 'int'), total=t.amount.sum())

--- a/blaze/compute/tests/test_sparksql.py
+++ b/blaze/compute/tests/test_sparksql.py
@@ -334,8 +334,8 @@ def test_by_non_native_ops(ctx, db):
     assert list(map(set, into(list, result))) == list(map(set, into(list, expected)))
 
 
-def test_strlen(ctx, db):
-    expr = db.t.name.strlen()
+def test_str_len(ctx, db):
+    expr = db.t.name.str_len()
     result = odo(compute(expr, ctx, return_type='native'), pd.Series)
     expected = compute(expr, {db: {'t': df}}, return_type='native')
     assert result.name == 'name'

--- a/blaze/compute/tests/test_sql_compute.py
+++ b/blaze/compute/tests/test_sql_compute.py
@@ -786,10 +786,24 @@ def test_not_like():
     WHERE accounts.name NOT LIKE :name_1""")
 
 
-def test_strlen():
-    expr = t.name.strlen()
+def test_str_len():
+    expr = t.name.str_len()
     result = str(compute(expr, s, return_type='native'))
     expected = "SELECT char_length(accounts.name) as name FROM accounts"
+    assert normalize(result) == normalize(expected)
+
+
+def test_str_upper():
+    expr = t.name.str_upper()
+    result = str(compute(expr, s, return_type='native'))
+    expected = "SELECT upper(accounts.name) as name FROM accounts"
+    assert normalize(result) == normalize(expected)
+
+    
+def test_str_lower():
+    expr = t.name.str_lower()
+    result = str(compute(expr, s, return_type='native'))
+    expected = "SELECT lower(accounts.name) as name FROM accounts"
     assert normalize(result) == normalize(expected)
 
 

--- a/blaze/expr/strings.py
+++ b/blaze/expr/strings.py
@@ -8,7 +8,7 @@ from .expressions import schema_method_list, ElemWise
 from .arithmetic import Interp, Repeat, _mkbin, repeat, interp, _add, _radd
 from ..compatibility import basestring
 
-__all__ = ['Like', 'like', 'strlen', 'UnaryStringFunction']
+__all__ = ['Like', 'like', 'strlen', 'str_len', 'str_upper', 'str_lower', 'UnaryStringFunction']
 
 
 class Like(ElemWise):
@@ -48,14 +48,23 @@ class UnaryStringFunction(ElemWise):
 
 
 class strlen(UnaryStringFunction):
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn("`strlen()` has been deprecated in 0.10 and will be "
+                      "removed in 0.11.  Use ``str_len()`` instead.",
+                      DeprecationWarning)
+        super(self, strlen).__init__(*args, **kwargs)
+
+
+class str_len(UnaryStringFunction):
     schema = datashape.int64
 
 
-class strupper(UnaryStringFunction):
+class str_upper(UnaryStringFunction):
     schema = datashape.string
 
 
-class strlower(UnaryStringFunction):
+class str_lower(UnaryStringFunction):
     schema = datashape.string
 
 
@@ -68,11 +77,17 @@ _mod, _rmod = _mkbin('mod', Interp)
 _mul, _rmul = _mkbin('mul', Repeat)
 
 
-schema_method_list.extend([
-    (
-        isstring,
-        set([
-            _add, _radd, _mod, _rmod, _mul, _rmul, repeat, interp, like, strlen, strupper, strlower
-        ])
-    )
-])
+schema_method_list.extend([(isstring,
+                            set([_add,
+                                 _radd,
+                                 _mod,
+                                 _rmod,
+                                 _mul,
+                                 _rmul,
+                                 repeat,
+                                 interp,
+                                 like,
+                                 str_len,
+                                 strlen,
+                                 str_upper,
+                                 str_lower]))])

--- a/blaze/expr/strings.py
+++ b/blaze/expr/strings.py
@@ -51,6 +51,14 @@ class strlen(UnaryStringFunction):
     schema = datashape.int64
 
 
+class strupper(UnaryStringFunction):
+    schema = datashape.string
+
+
+class strlower(UnaryStringFunction):
+    schema = datashape.string
+
+
 def isstring(ds):
     measure = ds.measure
     return isinstance(getattr(measure, 'ty', measure), String)
@@ -64,7 +72,7 @@ schema_method_list.extend([
     (
         isstring,
         set([
-            _add, _radd, _mod, _rmod, _mul, _rmul, repeat, interp, like, strlen
+            _add, _radd, _mod, _rmod, _mul, _rmul, repeat, interp, like, strlen, strupper, strlower
         ])
     )
 ])

--- a/blaze/tests/test_interactive.py
+++ b/blaze/tests/test_interactive.py
@@ -106,9 +106,9 @@ def test_str_does_not_repr():
     # see GH issue #1240.
     d = data([('aa', 1), ('b', 2)], name="ZZZ",
              dshape='2 * {a: string, b: int64}')
-    expr = transform(d, c=d.a.strlen() + d.b)
+    expr = transform(d, c=d.a.str_len() + d.b)
     assert str(
-        expr) == "Merge(_child=ZZZ, children=(ZZZ, label(strlen(_child=ZZZ.a) + ZZZ.b, 'c')))"
+        expr) == "Merge(_child=ZZZ, children=(ZZZ, label(str_len(_child=ZZZ.a) + ZZZ.b, 'c')))"
 
 
 def test_repr_of_scalar():

--- a/docs/source/whatsnew/0.10.0.txt
+++ b/docs/source/whatsnew/0.10.0.txt
@@ -56,11 +56,17 @@ Improved Backends
 Experimental Features
 ~~~~~~~~~~~~~~~~~~~~~
 
-None
+* The :class:`~blaze.expr.strings.str_upper` and
+  :class:`~blaze.expr.strings.str_lower` expressions were added for the Pandas
+  and SQL backends (:issue:`1462`).  These are marked experimental since their
+  names are subject to change.  More string methods will be added in coming
+  versions.
 
 API Changes
 ~~~~~~~~~~~
 
+* The :class:`~blaze.expr.strings.strlen` expression was deprecated in favor of
+  :class:`~blaze.expr.strings.str_len` (:issue:`1462`).
 * Long deprecated :func:`~blaze.table.Table` and
   :func:`~blaze.table.TableSymbol` were removed (:issue:`1441`).  The
   ``TableSymbol`` tests in ``test_table.py`` were migrated to


### PR DESCRIPTION
This starts the process of expanding Blaze's string column support to include `upper` and `lower`.  This is useful since having first-class (and optimized) support for common string operations is useful for the string-munging pain points that users hit.

I'm marking these as part of the "experimental" API currently, since I'm not wild about the `str_upper`, `str_lower`, etc. naming scheme.  I'd like to find a better naming system for these if we can.

We have immediate need for `upper` and `lower`, so I'm putting these in for 0.10.

Regarding naming schemes: I like the Pandas' style `df.col.str.upper().str.replace(...)`.  We could expand that to include `df.col.dt.datetimemethod()` for datetimes as well.

We'll have to think about which string and datetime methods we want to support, for which backends, and what are the semantics when the method in question returns multiple values.  All of that is outside the scope for this PR.

This PR also deprecates `strlen` and adds `str_len` for consistency.