### PR TITLE
Add str_cat() to pandas and sql to concatenate string columns

### DIFF
--- a/blaze/compute/pandas.py
+++ b/blaze/compute/pandas.py
@@ -98,6 +98,7 @@ from ..expr import (
     summary,
     symbol,
     var,
+    str_cat,
 )
 
 __all__ = []
@@ -294,6 +295,19 @@ string_func_names = {'str_len': 'len',
 def compute_up(expr, data, **kwargs):
     name = type(expr).__name__
     return getattr(data.str, string_func_names.get(name, name))()
+
+
+@dispatch(str_cat, Series, Series)
+def compute_up(expr, *data, **kwargs):
+    # What is best way to access data since it is in multiple places
+    #     data[0] is n_name series
+    #     data[1] is n_comment series
+    #     also passing in scope
+    # should probably also check that both columns are strings
+    scope = kwargs.get('scope')
+    cat_ = getattr(getattr(scope[expr._child], 'str'), 'cat')
+    res = cat_(scope[expr.col], sep=expr.sep)
+    return res
 
 
 def unpack(seq):

--- a/blaze/compute/pandas.py
+++ b/blaze/compute/pandas.py
@@ -98,7 +98,7 @@ from ..expr import (
     summary,
     symbol,
     var,
-    str_cat,
+    StrCat,
 )
 
 __all__ = []
@@ -297,16 +297,9 @@ def compute_up(expr, data, **kwargs):
     return getattr(data.str, string_func_names.get(name, name))()
 
 
-@dispatch(str_cat, Series, Series)
-def compute_up(expr, *data, **kwargs):
-    # What is best way to access data since it is in multiple places
-    #     data[0] is n_name series
-    #     data[1] is n_comment series
-    #     also passing in scope
-    # should probably also check that both columns are strings
-    scope = kwargs.get('scope')
-    cat_ = getattr(getattr(scope[expr._child], 'str'), 'cat')
-    res = cat_(scope[expr.col], sep=expr.sep)
+@dispatch(StrCat, Series, Series)
+def compute_up(expr, lhs_data, rhs_data, **kwargs):
+    res = lhs_data.str.cat(rhs_data, sep=expr.sep)
     return res
 
 

--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -1208,7 +1208,8 @@ def compute_up(expr, data, **kwargs):
 
 @dispatch(StrCat, ColumnElement, ColumnElement)
 def compute_up(expr, lhs_data, rhs_data, **kwargs):
-    res = (sa.sql.functions.concat(lhs_data, expr.sep,
+    res = (sa.sql.functions.concat(lhs_data,
+                                   expr.sep,
                                    rhs_data).label(lhs_data.name))
     return res
 

--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -1218,6 +1218,9 @@ def compute_up(expr, lhs_data, rhs_data, **kwargs):
     e.g.
         t.name.str_cat(t.comment.str_cat(t.sex, sep=' -- '), sep=' ++ ')
     """
+    if lhs_data._from_objects != rhs_data._from_objects:
+        raise ValueError('cannot concat columns from different tables')
+
     if isinstance(rhs_data, Select):
         # this gives desired result by mutating the select in place instead
         # of chaining

--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -1208,9 +1208,9 @@ def compute_up(expr, data, **kwargs):
 
 @dispatch(StrCat, ColumnElement, ColumnElement)
 def compute_up(expr, lhs_data, rhs_data, **kwargs):
-    res = (sa.sql.functions.concat(lhs_data,
-                                   expr.sep,
-                                   rhs_data).label(expr.lhs._name))
+    res = sa.sql.functions.concat(lhs_data,
+                                  expr.sep,
+                                  rhs_data).label(expr.lhs._name)
     return res
 
 

--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -1210,7 +1210,7 @@ def compute_up(expr, data, **kwargs):
 def compute_up(expr, lhs_data, rhs_data, **kwargs):
     res = (sa.sql.functions.concat(lhs_data,
                                    expr.sep,
-                                   rhs_data).label(lhs_data.name))
+                                   rhs_data).label(expr.lhs._name))
     return res
 
 

--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -1218,16 +1218,21 @@ def compute_up(expr, lhs_data, rhs_data, **kwargs):
     e.g.
         t.name.str_cat(t.comment.str_cat(t.sex, sep=' -- '), sep=' ++ ')
     """
-    if lhs_data._from_objects != rhs_data._from_objects:
-        raise ValueError('cannot concat columns from different tables')
+    err = 'cannot concat columns from different tables'
 
     if isinstance(rhs_data, Select):
+        if lhs_data._from_objects != rhs_data._from_objects[0].froms:
+            raise ValueError(err)
+
         # this gives desired result by mutating the select in place instead
         # of chaining
         rhs_data.append_column(lhs_data)
         a_rhs = rhs_data.alias()
         rhs_data = a_rhs.columns._all_columns[0]
         lhs_data = a_rhs.columns._all_columns[1]
+    else:
+        if lhs_data._from_objects != rhs_data._from_objects:
+            raise ValueError(err)
 
     if expr.sep is None:
         # this will automatically handle null values correctly

--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -90,6 +90,7 @@ from ..expr import (
     std,
     str_len,
     strlen,
+    str_cat,
     var,
 )
 from ..expr.broadcast import broadcast_collect
@@ -1185,7 +1186,7 @@ def compute_up(t, s, **kwargs):
 string_func_names = {
     # <blaze function name>: <SQL function name>
     'str_upper': 'upper',
-    'str_lower': 'lower',
+    'str_lower': 'lower'
 }
 
 
@@ -1203,6 +1204,16 @@ def compile_char_length_on_hive(element, compiler, **kwargs):
 @dispatch((strlen, str_len), ColumnElement)
 def compute_up(expr, data, **kwargs):
     return sa.sql.functions.char_length(data).label(expr._name)
+
+
+@dispatch(str_cat, ColumnElement, ColumnElement)
+def compute_up(expr, *data, **kwargs):
+    scope = kwargs.get('scope')
+    col1 = scope[expr._child]
+    col2 = scope[expr.col]
+    res = (getattr(sa.sql.func, 'concat')
+           (col1, expr.sep, col2).label(col1.name))
+    return res
 
 
 @dispatch(UnaryStringFunction, ColumnElement)

--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -90,7 +90,7 @@ from ..expr import (
     std,
     str_len,
     strlen,
-    str_cat,
+    StrCat,
     var,
 )
 from ..expr.broadcast import broadcast_collect
@@ -1206,13 +1206,10 @@ def compute_up(expr, data, **kwargs):
     return sa.sql.functions.char_length(data).label(expr._name)
 
 
-@dispatch(str_cat, ColumnElement, ColumnElement)
-def compute_up(expr, *data, **kwargs):
-    scope = kwargs.get('scope')
-    col1 = scope[expr._child]
-    col2 = scope[expr.col]
-    res = (getattr(sa.sql.func, 'concat')
-           (col1, expr.sep, col2).label(col1.name))
+@dispatch(StrCat, ColumnElement, ColumnElement)
+def compute_up(expr, lhs_data, rhs_data, **kwargs):
+    res = (sa.sql.functions.concat(lhs_data, expr.sep,
+                                   rhs_data).label(lhs_data.name))
     return res
 
 

--- a/blaze/compute/tests/test_pandas_compute.py
+++ b/blaze/compute/tests/test_pandas_compute.py
@@ -45,17 +45,12 @@ dfbig = DataFrame([['Alice', 'F', 100, 1],
                   columns=['name', 'sex', 'amount', 'id'])
 
 
-@pytest.fixture(scope='module',
-                params=['lhs', 'rhs', 'both'])
-def df_add_null(request):
-    if request.param == 'lhs':
-        row = [None, 'M', 300, 6]
-    elif request.param == 'rhs':
-        row = ['first', None, 300, 6]
-    else:
-        row = [None, None, 300, 6]
-
-    df_add_null = dfbig.append(DataFrame([row],
+@pytest.fixture(scope='module')
+def df_add_null():
+    rows = [(None, 'M', 300, 6),
+            ('first', None, 300, 6),
+            (None, None, 300, 6)]
+    df_add_null = dfbig.append(DataFrame(rows,
                                          columns=dfbig.columns
                                          ), ignore_index=True)
 
@@ -710,10 +705,9 @@ def test_str_cat_sep():
 def test_str_cat_null_row(df_add_null):
     res = compute(tbig.name.str_cat(tbig.sex, sep=' -- '), df_add_null)
     exp_res = df_add_null.name.str.cat(df_add_null.sex, sep=' -- ')
-    assert all(exp_res[~exp_res.isnull()] == res[~exp_res.isnull()])
 
-    # last element should be null
-    assert res.isnull().iloc[-1]
+    assert all(exp_res.isnull() == res.isnull())
+    assert all(exp_res[~exp_res.isnull()] == res[~res.isnull()])
 
 
 def test_rowwise_by():

--- a/blaze/compute/tests/test_pandas_compute.py
+++ b/blaze/compute/tests/test_pandas_compute.py
@@ -687,14 +687,6 @@ class TestStrCat():
             ('jinka', 'this is ok', 2)]
     df = pd.DataFrame(data, columns=['name', 'comment', 'num'])
 
-    def test_str_cat_exception_no_column_to_concat(self):
-        with pytest.raises(TypeError):
-            compute(self.s.name.str_cat(), self.df)
-
-    def test_str_cat_exception_non_string_col_to_cat(self):
-        with pytest.raises(TypeError):
-            compute(self.s.name.str_cat(self.s.num), self.df)
-
     def test_str_cat(self):
         res = compute(self.s.name.str_cat(self.s.comment), self.df)
         assert all(self.df.name.str.cat(self.df.comment) == res)

--- a/blaze/compute/tests/test_pandas_compute.py
+++ b/blaze/compute/tests/test_pandas_compute.py
@@ -680,6 +680,29 @@ def test_str_lower():
     assert_series_equal(expected, result)
 
 
+class TestStrCat():
+    ds = dshape('3 * {name: string[10], comment: string[25], num: int32}')
+    s = symbol('s', dshape=ds)
+    data = [('alice', 'this is good', 0), ('suri', 'this is not good', 1),
+            ('jinka', 'this is ok', 2)]
+    df = pd.DataFrame(data, columns=['name', 'comment', 'num'])
+
+    def test_str_cat_exception_no_column_to_concat(self):
+        with pytest.raises(TypeError):
+            compute(self.s.name.str_cat(), self.df)
+
+    def test_str_cat_exception_non_string_col_to_cat(self):
+        with pytest.raises(TypeError):
+            compute(self.s.name.str_cat(self.s.num), self.df)
+
+    def test_str_cat(self):
+        res = compute(self.s.name.str_cat(self.s.comment), self.df)
+        assert all(self.df.name.str.cat(self.df.comment) == res)
+
+    def test_str_cat_sep(self):
+        res = compute(self.s.name.str_cat(self.s.comment, sep=' -- '), self.df)
+        assert all(self.df.name.str.cat(self.df.comment, sep=' -- ') == res)
+
 
 def test_rowwise_by():
     f = lambda _, id, name: id + len(name)

--- a/blaze/compute/tests/test_pandas_compute.py
+++ b/blaze/compute/tests/test_pandas_compute.py
@@ -45,6 +45,24 @@ dfbig = DataFrame([['Alice', 'F', 100, 1],
                   columns=['name', 'sex', 'amount', 'id'])
 
 
+# for now jsut copy this, but will open a PR to see if we can remove some of
+# the repetitive copying
+tbgr = symbol('tbgr',
+              """ var * {name: string,
+                         sex: string[1],
+                         amount: int,
+                         id: int,
+                         comment: ?string}
+              """)
+
+dfbgr = DataFrame([['Alice', 'F', 100, 1, 'Alice comment'],
+                   ['Alice', 'F', 100, 3, None],
+                   ['Drew', 'F', 100, 4, 'Drew comment'],
+                   ['Drew', 'M', 100, 5, 'Drew comment 2'],
+                   ['Drew', 'M', 200, 5, None]],
+                  columns=['name', 'sex', 'amount', 'id', 'comment'])
+
+
 @pytest.fixture(scope='module')
 def df_add_null():
     rows = [(None, 'M', 300, 6),
@@ -706,6 +724,16 @@ def test_str_cat_null_row(df_add_null):
     res = compute(tbig.name.str_cat(tbig.sex, sep=' -- '), df_add_null)
     exp_res = df_add_null.name.str.cat(df_add_null.sex, sep=' -- ')
 
+    assert all(exp_res.isnull() == res.isnull())
+    assert all(exp_res[~exp_res.isnull()] == res[~res.isnull()])
+
+
+def test_str_cat_chain_operation():
+    expr = tbgr.name.str_cat(tbgr.comment.str_cat(tbgr.sex, sep=' --- '),
+                             sep=' +++ ')
+    res = compute(expr, dfbgr)
+    exp_res = dfbgr.name.str.cat(dfbgr.comment.str.cat(dfbgr.sex, sep=' --- '),
+                                 sep=' +++ ')
     assert all(exp_res.isnull() == res.isnull())
     assert all(exp_res[~exp_res.isnull()] == res[~res.isnull()])
 

--- a/blaze/compute/tests/test_postgresql_compute.py
+++ b/blaze/compute/tests/test_postgresql_compute.py
@@ -667,6 +667,26 @@ def test_sample(big_sql):
     assert len(result) == len(result2)
 
 
+@pytest.mark.parametrize("sep", [None, " -- "])
+def test_str_cat(nyc, sep):
+    """
+    test str_cat() functionality for postgres backend
+    """
+    t = symbol('t', discover(nyc))
+    res = compute(t.medallion.str_cat(t.hack_license, sep=sep), nyc,
+                  return_type=list)
+    cols = compute(t[['medallion', 'hack_license']], nyc, return_type=list)
+
+    if sep is None:
+        expected = map(lambda x: "".join(x), cols)
+    else:
+        expected = map(lambda x: sep.join(x), cols)
+
+    actual = map(lambda x: x[0], res)
+    for exp, act in zip(expected, actual):
+        assert exp == act
+
+
 def test_core_compute(nyc):
     t = symbol('t', discover(nyc))
     assert isinstance(compute(t, nyc, return_type='core'), pd.DataFrame)

--- a/blaze/compute/tests/test_postgresql_compute.py
+++ b/blaze/compute/tests/test_postgresql_compute.py
@@ -728,6 +728,22 @@ def test_chain_str_cat_with_null(sql_with_null):
             assert (r == n + ' ++ ' + c + ' -- ' + s)
 
 
+def test_str_cat_where_clause(sql_with_null):
+    """
+    Invokes the (Select, Select) path for compute_up
+    """
+    t = symbol('t', discover(sql_with_null))
+    s = t[t.amount <= 200]
+    c1 = s.comment.str_cat(s.sex, sep=' -- ')
+
+    bres = compute(c1, sql_with_null, return_type=pd.Series)
+    df_s = compute(s, sql_with_null, return_type=pd.DataFrame)
+    exp = df_s.comment.str.cat(df_s.sex, ' -- ')
+
+    assert all(exp[~exp.isnull()] == bres[~bres.isnull()])
+    assert all(exp[exp.isnull()].index == bres[bres.isnull()].index)
+
+
 def test_core_compute(nyc):
     t = symbol('t', discover(nyc))
     assert isinstance(compute(t, nyc, return_type='core'), pd.DataFrame)

--- a/blaze/compute/tests/test_sql_compute.py
+++ b/blaze/compute/tests/test_sql_compute.py
@@ -872,6 +872,14 @@ def test_str_cat_runtime_exception(expr):
         compute(expr, {t: s, t_str_cat: s_str_cat}, return_type='native')
 
 
+def test_str_cat_no_runtime_exception():
+    """
+    No exception raised if resource is the same
+    """
+    expr = t.name.str_cat(t_str_cat.comment)
+    compute(expr, {t: s, t_str_cat: s}, return_type='native')
+
+
 def test_columnwise_on_complex_selection():
     result = str(select(compute(t[t.amount > 0].amount + 1, s, return_type='native')))
     assert normalize(result) == \

--- a/blaze/compute/tests/test_sql_compute.py
+++ b/blaze/compute/tests/test_sql_compute.py
@@ -876,8 +876,8 @@ def test_str_cat_no_runtime_exception():
     """
     No exception raised if resource is the same
     """
-    expr = t.name.str_cat(t_str_cat.comment)
-    compute(expr, {t: s, t_str_cat: s}, return_type='native')
+    expr = t_str_cat.comment.str_cat(t.name)
+    compute(expr, {t: s_str_cat, t_str_cat: s_str_cat}, return_type='native')
 
 
 def test_columnwise_on_complex_selection():

--- a/blaze/compute/tests/test_sql_compute.py
+++ b/blaze/compute/tests/test_sql_compute.py
@@ -860,6 +860,18 @@ def test_str_cat(sep):
     assert normalize(result) == normalize(expected)
 
 
+@pytest.mark.parametrize("expr",
+                         [t.name.str_cat(t_str_cat.comment),
+                          t.name.str_cat(t_str_cat.comment.str_cat(t_str_cat.name))])
+def test_str_cat_runtime_exception(expr):
+    """
+    concat columns within the same table for SQL
+    """
+    with pytest.raises(ValueError):
+        # ValueError: cannot concat columns from different tables
+        compute(expr, {t: s, t_str_cat: s_str_cat}, return_type='native')
+
+
 def test_columnwise_on_complex_selection():
     result = str(select(compute(t[t.amount > 0].amount + 1, s, return_type='native')))
     assert normalize(result) == \

--- a/blaze/compute/tests/test_sql_compute.py
+++ b/blaze/compute/tests/test_sql_compute.py
@@ -860,6 +860,7 @@ def test_str_cat(sep):
     assert normalize(result) == normalize(expected)
 
 
+@pytest.mark.xfail(reason="raise exception code needed for refactored StrCat")
 @pytest.mark.parametrize("expr",
                          [t.name.str_cat(t_str_cat.comment),
                           t.name.str_cat(t_str_cat.comment.str_cat(t_str_cat.name))])

--- a/blaze/compute/tests/test_sql_compute.py
+++ b/blaze/compute/tests/test_sql_compute.py
@@ -78,7 +78,13 @@ def city_data():
 
 
 t = symbol('t', 'var * {name: string, amount: int, id: int}')
-t2 = symbol('t', 'var * {name: string, amount: int, id: int, comment: string}')
+t_str_cat = symbol('t',
+                   """var * {name: string,
+                             amount: int,
+                             id: int,
+                             comment: string,
+                             product: string}""")
+
 nt = symbol('t', 'var * {name: ?string, amount: float64, id: int}')
 
 metadata = sa.MetaData()
@@ -88,11 +94,12 @@ s = sa.Table('accounts', metadata,
              sa.Column('amount', sa.Integer),
              sa.Column('id', sa.Integer, primary_key=True))
 
-s2 = sa.Table('accounts2', metadata,
-              sa.Column('name', sa.String),
-              sa.Column('amount', sa.Integer),
-              sa.Column('id', sa.Integer, primary_key=True),
-              sa.Column('comment', sa.String))
+s_str_cat = sa.Table('accounts2', metadata,
+                     sa.Column('name', sa.String),
+                     sa.Column('amount', sa.Integer),
+                     sa.Column('id', sa.Integer, primary_key=True),
+                     sa.Column('comment', sa.String),
+                     sa.Column('product', sa.String))
 
 tdate = symbol('t',
                """var * {
@@ -830,13 +837,13 @@ def test_str_cat(sep):
     Need at least two string columns to test str_cat
     """
     if sep is None:
-        expr = t2.name.str_cat(t2.comment)
+        expr = t_str_cat.name.str_cat(t_str_cat.comment)
         expected = """
                    SELECT accounts2.name || accounts2.comment
                    AS name FROM accounts2
                    """
     else:
-        expr = t2.name.str_cat(t2.comment, sep=sep)
+        expr = t_str_cat.name.str_cat(t_str_cat.comment, sep=sep)
         expected = \
             """
             SELECT
@@ -849,7 +856,7 @@ def test_str_cat(sep):
             FROM accounts2
            """
 
-    result = str(compute(expr, s2, return_type='native'))
+    result = str(compute(expr, s_str_cat, return_type='native'))
     assert normalize(result) == normalize(expected)
 
 

--- a/blaze/expr/strings.py
+++ b/blaze/expr/strings.py
@@ -110,7 +110,15 @@ class StrCat(ElemWise):
         '''
         since pandas supports concat for string columns, do the same for blaze
         '''
-        shape, schema = self.lhs.dshape.shape, DataShape(String())
+        shape = self.lhs.dshape.shape
+        if isinstance(self.lhs.schema.measure, Option):
+            schema = self.lhs.schema
+        elif isinstance(self.rhs.schema.measure, Option):
+            schema = self.rhs.schema
+        else:
+            # convert fixed length string to variable length string
+            schema = DataShape(String())
+
         return DataShape(*(shape + (schema,)))
 
 

--- a/blaze/expr/strings.py
+++ b/blaze/expr/strings.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import warnings
+
 import datashape
 from datashape import String, DataShape, Option, bool_
 from odo.utils import copydoc

--- a/blaze/expr/strings.py
+++ b/blaze/expr/strings.py
@@ -91,7 +91,7 @@ class StrCat(ElemWise):
     >>> import pandas as pd
     >>> from blaze import symbol, compute, dshape
 
-    >>> ds = dshape('3 * {name: string[10], comment: string[25], num: int32}')
+    >>> ds = dshape('3 * {name: ?string, comment: ?string, num: int32}')
     >>> s = symbol('s', dshape=ds)
     >>> data = [('al', 'good', 0), ('suri', 'not good', 1), ('jinka', 'ok', 2)]
     >>> df = pd.DataFrame(data, columns=['name', 'comment', 'num'])
@@ -100,6 +100,17 @@ class StrCat(ElemWise):
     0          al -- good
     1    suri -- not good
     2         jinka -- ok
+    Name: name, dtype: object
+
+    For rows with null entries, it returns null. This is consistent with
+    default pandas behavior with kwarg: na_rep=None.
+
+    >>> data = [(None, None, 0), ('suri', 'not good', 1), ('jinka', None, 2)]
+    >>> df = pd.DataFrame(data, columns=['name', 'comment', 'num'])
+    >>> compute(s.name.str_cat(s.comment, sep=' -- '), df)
+    0                 NaN
+    1    suri -- not good
+    2                 NaN
     Name: name, dtype: object
 
     """

--- a/blaze/expr/strings.py
+++ b/blaze/expr/strings.py
@@ -93,9 +93,7 @@ class StrCat(ElemWise):
 
     >>> ds = dshape('3 * {name: string[10], comment: string[25], num: int32}')
     >>> s = symbol('s', dshape=ds)
-    >>> data = [('alice', 'this is good', 0),
-                ('suri', 'this is not good', 1),
-                ('jinka', 'this is ok', 2)]
+    >>> data = [('alice', 'this is good', 0), ('suri', 'this is not good', 1), ('jinka', 'this is ok', 2)]
     >>> df = pd.DataFrame(data, columns=['name', 'comment', 'num'])
 
     >>> compute(s.name.str_cat(s.comment, sep=' -- '), df)

--- a/blaze/expr/strings.py
+++ b/blaze/expr/strings.py
@@ -117,9 +117,7 @@ class StrCat(ElemWise):
         '''
         since pandas supports concat for string columns, do the same for blaze
         '''
-        new_s_len = \
-            self.lhs.schema.measure.fixlen + self.rhs.schema.measure.fixlen
-        shape, schema = self.lhs.dshape.shape, DataShape(String(new_s_len))
+        shape, schema = self.lhs.dshape.shape, DataShape(String())
         return DataShape(*(shape + (schema,)))
 
 

--- a/blaze/expr/strings.py
+++ b/blaze/expr/strings.py
@@ -129,6 +129,10 @@ def str_cat(expr, to_concat, sep=None):
     if not isstring(to_concat.dshape):
         raise TypeError("can only concat string columns")
 
+    if sep is not None:
+        if not isinstance(sep, basestring):
+            raise TypeError("keyword argument 'sep' must be a String")
+
     return StrCat(expr, to_concat, sep=sep)
 
 

--- a/blaze/expr/strings.py
+++ b/blaze/expr/strings.py
@@ -123,21 +123,23 @@ class StrCat(ElemWise):
 
 
 @copydoc(StrCat)
-def str_cat(expr, to_concat, sep=None):
+def str_cat(lhs, rhs, sep=None):
     """
+    returns lhs + sep + rhs
+
     Raises:
         Invoking on a non string column raises a TypeError
         If kwarg 'sep' is not a string, raises a TypeError
     """
     # pandas supports concat for string columns only, do the same for blaze
-    if not isstring(to_concat.dshape):
+    if not isstring(rhs.dshape):
         raise TypeError("can only concat string columns")
 
     if sep is not None:
         if not isinstance(sep, basestring):
             raise TypeError("keyword argument 'sep' must be a String")
 
-    return StrCat(expr, to_concat, sep=sep)
+    return StrCat(lhs, rhs, sep=sep)
 
 
 def isstring(ds):

--- a/blaze/expr/strings.py
+++ b/blaze/expr/strings.py
@@ -89,8 +89,7 @@ class StrCat(ElemWise):
     Concatenate two string columns together with optional 'sep' argument.
 
     >>> import pandas as pd
-    >>> from blaze.expr import symbol, compute
-    >>> from datashape import dshape
+    >>> from blaze import symbol, compute, dshape
 
     >>> ds = dshape('3 * {name: string[10], comment: string[25], num: int32}')
     >>> s = symbol('s', dshape=ds)
@@ -98,15 +97,11 @@ class StrCat(ElemWise):
     >>> df = pd.DataFrame(data, columns=['name', 'comment', 'num'])
 
     >>> compute(s.name.str_cat(s.comment, sep=' -- '), df)
-        0       alice -- this is good
-        1    suri -- this is not good
-        2         jinka -- this is ok
+        0          al -- good
+        1    suri -- not good
+        2         jinka -- ok
         Name: name, dtype: object
 
-
-    Invoking str_cat() on a non string column raises a TypeError during compute
-    >>> compute(s.name.str_cat(s.num, sep=' -- '), df)
-    TypeError: can only concat string columns
     """
     __slots__ = '_hash', 'lhs', 'rhs', 'sep'
     __inputs__ = 'lhs', 'rhs'
@@ -121,6 +116,11 @@ class StrCat(ElemWise):
 
 @copydoc(StrCat)
 def str_cat(expr, to_concat, sep=None):
+    """
+    Raises:
+        Invoking on a non string column raises a TypeError
+        If kwarg 'sep' is not a string, raises a TypeError
+    """
     # pandas supports concat for string columns only, do the same for blaze
     if not isstring(to_concat.dshape):
         raise TypeError("can only concat string columns")

--- a/blaze/expr/strings.py
+++ b/blaze/expr/strings.py
@@ -97,10 +97,10 @@ class StrCat(ElemWise):
     >>> df = pd.DataFrame(data, columns=['name', 'comment', 'num'])
 
     >>> compute(s.name.str_cat(s.comment, sep=' -- '), df)
-        0          al -- good
-        1    suri -- not good
-        2         jinka -- ok
-        Name: name, dtype: object
+    0          al -- good
+    1    suri -- not good
+    2         jinka -- ok
+    Name: name, dtype: object
 
     """
     __slots__ = '_hash', 'lhs', 'rhs', 'sep'

--- a/blaze/expr/strings.py
+++ b/blaze/expr/strings.py
@@ -86,7 +86,7 @@ class str_lower(UnaryStringFunction):
 
 class StrCat(ElemWise):
     """
-    Concatenate two string columns together with optional 'sep' argument
+    Concatenate two string columns together with optional 'sep' argument.
 
     >>> from blaze.expr import symbol
     >>> from datashape import dshape
@@ -97,30 +97,29 @@ class StrCat(ElemWise):
                 ('suri', 'this is not good', 1),
                 ('jinka', 'this is ok', 2)]
     >>> df = pd.DataFrame(data, columns=['name', 'comment', 'num'])
+
     >>> compute(s.name.str_cat(s.comment, sep=' -- '), df)
         0       alice -- this is good
         1    suri -- this is not good
         2         jinka -- this is ok
         Name: name, dtype: object
 
+
     Invoking str_cat() on a non string column raises a TypeError during compute
+
     >>> compute(s.name.str_cat(s.num, sep=' -- '), df)
     TypeError: can only concat string columns
-
-    Invoking str_cat() with no arguments raises TypeError
-    >>> s.name.str_cat()
-    TypeError: require column to concatenate
     """
-    __slots__ = '_hash', '_child', 'col', 'sep'
-    __inputs__ = '_child', 'col'
+    __slots__ = '_hash', 'lhs', 'rhs', 'sep'
+    __inputs__ = 'lhs', 'rhs'
 
     def _dshape(self):
         '''
         since pandas supports concat for string columns, do the same for blaze
         '''
         new_s_len = \
-            self._child.schema.measure.fixlen + self.col.schema.measure.fixlen
-        shape, schema = self._child.dshape.shape, DataShape(String(new_s_len))
+            self.lhs.schema.measure.fixlen + self.rhs.schema.measure.fixlen
+        shape, schema = self.lhs.dshape.shape, DataShape(String(new_s_len))
         return DataShape(*(shape + (schema,)))
 
 

--- a/blaze/expr/strings.py
+++ b/blaze/expr/strings.py
@@ -88,12 +88,13 @@ class StrCat(ElemWise):
     """
     Concatenate two string columns together with optional 'sep' argument.
 
-    >>> from blaze.expr import symbol
+    >>> import pandas as pd
+    >>> from blaze.expr import symbol, compute
     >>> from datashape import dshape
 
     >>> ds = dshape('3 * {name: string[10], comment: string[25], num: int32}')
     >>> s = symbol('s', dshape=ds)
-    >>> data = [('alice', 'this is good', 0), ('suri', 'this is not good', 1), ('jinka', 'this is ok', 2)]
+    >>> data = [('al', 'good', 0), ('suri', 'not good', 1), ('jinka', 'ok', 2)]
     >>> df = pd.DataFrame(data, columns=['name', 'comment', 'num'])
 
     >>> compute(s.name.str_cat(s.comment, sep=' -- '), df)
@@ -104,7 +105,6 @@ class StrCat(ElemWise):
 
 
     Invoking str_cat() on a non string column raises a TypeError during compute
-
     >>> compute(s.name.str_cat(s.num, sep=' -- '), df)
     TypeError: can only concat string columns
     """

--- a/blaze/expr/tests/test_strings.py
+++ b/blaze/expr/tests/test_strings.py
@@ -13,7 +13,8 @@ lhsrhs_ds = ['var * {name: string, comment: string[25]}',
              'var * {name: string[10], comment: string}',
              'var * {name: string, comment: string}',
              'var * {name: ?string, comment: string}',
-             'var * {name: string, comment: ?string}']
+             'var * {name: string, comment: ?string}',
+             '10 * {name: string, comment: ?string}']
 
 
 @pytest.fixture(scope='module')
@@ -47,11 +48,12 @@ def test_str_upper_schema(ds):
 
 
 @pytest.mark.parametrize('ds', lhsrhs_ds)
-def test_str_schema(ds):
+def test_str_cat_schema_shape(ds):
     t = symbol('t', ds)
     expr = t.name.str_cat(t.comment)
     assert (expr.schema.measure ==
             dshape('%sstring' % ('?' if '?' in ds else '')).measure)
+    assert expr.lhs.shape == expr.rhs.shape == expr.shape
 
 
 def test_str_cat_exception_non_string_sep(strcat_sym):

--- a/blaze/expr/tests/test_strings.py
+++ b/blaze/expr/tests/test_strings.py
@@ -1,4 +1,3 @@
-import datashape
 import pytest
 from datashape import dshape
 
@@ -28,3 +27,16 @@ def test_str_upper_schema(ds):
     assert (expr_upper.schema.measure ==
             expr_lower.schema.measure ==
             dshape('%sstring' % ('?' if '?' in ds else '')).measure)
+
+
+class TestStrCatExceptions():
+    ds = dshape('3 * {name: string[10], comment: string[25], num: int32}')
+    s = symbol('s', dshape=ds)
+
+    def test_str_cat_exception_non_string_sep(self):
+        with pytest.raises(TypeError):
+            self.s.name.str_cat(self.s.comment, sep=123)
+
+    def test_str_cat_exception_non_string_col_to_cat(self):
+        with pytest.raises(TypeError):
+            self.s.name.str_cat(self.s.num)


### PR DESCRIPTION
- Added str_cat() to concatenate two string columns with `sep=` kwarg.
- Added tests for pandas and tests to validate the compiled SQL query.
- Added test for postgres backend.

Also, still need to implement str_cat() when inputs are Select as opposed to ColumnElement, which is a bit more complex