### PR TITLE
BUG: Fix test_mysql_compute.py::test_agg_sql expected value

### DIFF
--- a/blaze/compute/tests/test_mysql_compute.py
+++ b/blaze/compute/tests/test_mysql_compute.py
@@ -50,7 +50,7 @@ def test_agg_sql(db, data):
             nyc.passenger_count as passenger_count
          from
             nyc
-         where nyc.passenger_count < %s) as alias
+         where nyc.passenger_count < %(passenger_count_1)s) as alias
     """
     assert normalize(str(result)) == normalize(expected)
 


### PR DESCRIPTION
As of today, mysql tests are skipped on travis. Locally, `test_mysql_compute.py::test_agg_sql` fails, this PR fixes it valid input for `normalize` function.

Any specific reason for not validating mysql tests on travis?