### PR TITLE
Brain dead server logging

### DIFF
--- a/blaze/server/spider.py
+++ b/blaze/server/spider.py
@@ -149,7 +149,7 @@ def _parse_args():
     p = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     p.add_argument('path', type=argparse.FileType('r'), nargs='?',
-                   default=sys.stdin,
+                   default=None,
                    help='A YAML file specifying the resources to load')
     p.add_argument('-p', '--port', type=int, default=DEFAULT_PORT,
                    help='Port number')
@@ -173,12 +173,18 @@ def _parse_args():
 
 def _main():
     args = _parse_args()
+    if not (args.path or args.allow_dynamic_addition):
+        msg = "No YAML file provided and --allow-dynamic-addition flag not set."
+        raise RuntimeError(msg)
     ignore = tuple(getattr(builtins, e) for e in args.ignored_exception)
-    resources = from_yaml(args.path,
-                          ignore=ignore,
-                          followlinks=args.follow_links,
-                          hidden=args.hidden,
-                          relative_to_yaml_dir=args.yaml_dir)
+    if args.path:
+        resources = from_yaml(args.path,
+                              ignore=ignore,
+                              followlinks=args.follow_links,
+                              hidden=args.hidden,
+                              relative_to_yaml_dir=args.yaml_dir)
+    else:
+        resources = {}
     server = Server(resources, allow_add=args.allow_dynamic_addition)
     server.run(host=args.host, port=args.port, debug=args.debug)
 

--- a/blaze/server/spider.py
+++ b/blaze/server/spider.py
@@ -168,14 +168,15 @@ def _parse_args():
                    help='Allow dynamically adding datasets to the server')
     p.add_argument('-D', '--debug', action='store_true',
                    help='Start the Flask server in debug mode')
-    return p.parse_args()
+    args = p.parse_args()
+    if not (args.path or args.allow_dynamic_addition):
+        msg = "No YAML file provided and --allow-dynamic-addition flag not set."
+        p.error(msg)
+    return args
 
 
 def _main():
     args = _parse_args()
-    if not (args.path or args.allow_dynamic_addition):
-        msg = "No YAML file provided and --allow-dynamic-addition flag not set."
-        raise RuntimeError(msg)
     ignore = tuple(getattr(builtins, e) for e in args.ignored_exception)
     if args.path:
         resources = from_yaml(args.path,

--- a/blaze/server/spider.py
+++ b/blaze/server/spider.py
@@ -168,6 +168,10 @@ def _parse_args():
                    help='Allow dynamically adding datasets to the server')
     p.add_argument('-D', '--debug', action='store_true',
                    help='Start the Flask server in debug mode')
+    p.add_argument('--log-file', type=str, default=None,
+                   help='Log file for warnings and errors.')
+    p.add_argument('--log-level', type=str, default='WARNING',
+                   help='Logging level.')
     args = p.parse_args()
     if not (args.path or args.allow_dynamic_addition):
         msg = "No YAML file provided and --allow-dynamic-addition flag not set."
@@ -186,7 +190,10 @@ def _main():
                               relative_to_yaml_dir=args.yaml_dir)
     else:
         resources = {}
-    server = Server(resources, allow_add=args.allow_dynamic_addition)
+    server = Server(resources,
+                    allow_add=args.allow_dynamic_addition,
+                    logfile=args.log_file,
+                    loglevel=args.log_level)
     server.run(host=args.host, port=args.port, debug=args.debug)
 
 

--- a/docs/source/whatsnew/0.11.0.txt
+++ b/docs/source/whatsnew/0.11.0.txt
@@ -1,0 +1,48 @@
+Release |version|
+-----------------
+
+:Release: |version|
+:Date: TBD
+
+New Expressions
+~~~~~~~~~~~~~~~
+
+None
+
+Improved Expressions
+~~~~~~~~~~~~~~~~~~~~
+
+None
+
+New Backends
+~~~~~~~~~~~~
+
+None
+
+Improved Backends
+~~~~~~~~~~~~~~~~~
+
+* Adds consistency check to blaze server at startup for YAML file and dynamic
+  addition options (:issue:`1491`).
+
+Experimental Features
+~~~~~~~~~~~~~~~~~~~~~
+
+None
+
+API Changes
+~~~~~~~~~~~
+
+None
+
+
+Bug Fixes
+~~~~~~~~~
+
+None
+
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+None


### PR DESCRIPTION
First cut at logging blaze server.  Adds a few cmdline flags for setup and initialization.

Of note is capturing the full traceback when `/compute` hits an exception, which is the primary thrust of this PR.

Comments and suggestions for improvement welcome.