### PR TITLE
Fix a bug with to_tree() and slice objects.

### DIFF
--- a/blaze/server/server.py
+++ b/blaze/server/server.py
@@ -387,16 +387,18 @@ def to_tree(expr, names=None):
 
     from_tree
     """
+    if isinstance(expr, slice):
+        # NOTE: This case must come first, since `slice` objects are not
+        # hashable, so a dict lookup inside `names` will raise an execption.
+        return {'op': 'slice',
+                'args': [to_tree(arg, names=names) for arg in
+                         [expr.start, expr.stop, expr.step]]}
     if names and expr in names:
         return names[expr]
     if isinstance(expr, tuple):
         return [to_tree(arg, names=names) for arg in expr]
     if isinstance(expr, expr_utils._slice):
         return to_tree(expr.as_slice(), names=names)
-    if isinstance(expr, slice):
-        return {'op': 'slice',
-                'args': [to_tree(arg, names=names) for arg in
-                         [expr.start, expr.stop, expr.step]]}
     elif isinstance(expr, _Data):
         return to_tree(symbol(expr._name, expr.dshape), names)
     elif isinstance(expr, Expr):

--- a/blaze/server/tests/test_server.py
+++ b/blaze/server/tests/test_server.py
@@ -15,7 +15,7 @@ from datetime import datetime
 import pandas as pd
 from pandas import DataFrame
 from pandas.util.testing import assert_frame_equal
-from toolz import pipe
+from toolz import pipe, partial
 
 from blaze.dispatch import dispatch
 from blaze.expr import Expr
@@ -173,7 +173,11 @@ def test_to_tree():
 def test_to_tree_slice(serial):
     t = symbol('t', 'var * {name: string, amount: int32}')
     expr = t[:5]
-    expr2 = pipe(expr, to_tree, serial.dumps, serial.loads, from_tree)
+    expr2 = pipe(expr,
+                 partial(to_tree, names={t: 't'}),
+                 serial.dumps,
+                 serial.loads,
+                 partial(from_tree, namespace={'t': t}))
     assert expr.isidentical(expr2)
 
 

--- a/docs/source/whatsnew/0.11.0.txt
+++ b/docs/source/whatsnew/0.11.0.txt
@@ -43,7 +43,9 @@ None
 Bug Fixes
 ~~~~~~~~~
 
-None
+* Fixed a bug with ``to_tree()`` and ``slice`` objects. Have to change the
+  order of cases in ``to_tree()`` to ensure ``slice`` objects are handled
+  before lookups inside the ``names`` namespace (:issue:`1516`).
 
 Miscellaneous
 ~~~~~~~~~~~~~


### PR DESCRIPTION
Have to change the order of cases in `to_tree()` to ensure `slice`
objects are handled before lookups inside the `names` namespace.

Test updated to exercise this case.

ping @ywang007