### PR TITLE
Improved server logging

### DIFF
--- a/blaze/server/server.py
+++ b/blaze/server/server.py
@@ -247,8 +247,9 @@ class FlaskWithExceptionFormatting(Flask):
     """
     log_exception_formatter = None
 
-    def __init__(self, *args, log_exception_formatter=None, **kwargs):
-        self.log_exception_formatter = log_exception_formatter
+    def __init__(self, *args, **kwargs):
+        self.log_exception_formatter = kwargs.pop('log_exception_formatter',
+                                                  _default_log_exception_formatter)
         super(FlaskWithExceptionFormatting, self).__init__(*args, **kwargs)
 
 

--- a/blaze/server/server.py
+++ b/blaze/server/server.py
@@ -356,7 +356,9 @@ class Server(object):
         self.port = port
         try:
             # Blocks until the server is shut down.
+            self.app.logger.debug('Starting server...')
             self.app.run(port=port, **kwargs)
+            self.app.logger.debug('Stopping server...')
         except socket.error:
             if not retry:
                 raise
@@ -578,8 +580,8 @@ def compserver(payload, serial):
         @response_construction_context_stack.callback
         def log_time(start=time()):
             app.logger.info('compute expr: %s\ntotal time (s): %.3f',
-                                          expr,
-                                          time() - start)
+                            expr,
+                            time() - start)
 
         ns = payload.get('namespace', {})
         compute_kwargs = payload.get('compute_kwargs') or {}
@@ -663,6 +665,7 @@ def addserver(payload, serial):
                 RC.UNPROCESSABLE_ENTITY)
 
     [(name, resource_info)] = payload.items()
+    flask.current_app.logger.debug("Attempting to add dataset '%s'" % name)
 
     if name in data:
         msg = "Cannot add dataset named %s, already exists on server."

--- a/blaze/server/server.py
+++ b/blaze/server/server.py
@@ -1,5 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
+import logging
+from logging import Formatter
+from functools import wraps
+import traceback
 import collections
 from datetime import datetime
 import errno
@@ -60,6 +64,17 @@ pickle_extension_api = Blueprint('pickle_extension_api', __name__)
 
 
 _no_default = object()  # sentinel
+
+
+def _logging(func):
+    @wraps(func)
+    def _logger(*args, **kwargs):
+        logger = flask.current_app.logger
+        logger.debug("Calling %s" % func.__name__)
+        ret = func(*args, **kwargs)
+        logger.debug("Leaving %s" % func.__name__)
+        return ret
+    return _logger
 
 
 def _get_option(option, options, default=_no_default):
@@ -285,7 +300,9 @@ class Server(object):
                  allow_profiler=False,
                  profiler_output=None,
                  profile_by_default=False,
-                 allow_add=False):
+                 allow_add=False,
+                 logfile=None,
+                 loglevel=None):
         if isinstance(data, collections.Mapping):
             data = valmap(lambda v: v.data if isinstance(v, _Data) else v,
                           data)
@@ -303,6 +320,12 @@ class Server(object):
                                profile_by_default=profile_by_default,
                                allow_add=allow_add)
         self.data = data
+        if logfile:
+            file_handler = logging.FileHandler(logfile)
+            file_handler.setFormatter(Formatter('[%(asctime)s %(levelname)s] %(message)s '
+                                                '[in %(pathname)s:%(lineno)d]'))
+            file_handler.setLevel(getattr(logging, loglevel, 'WARNING'))
+            app.logger.addHandler(file_handler)
 
     def run(self, port=DEFAULT_PORT, retry=False, **kwargs):
         """Run the server.
@@ -336,6 +359,7 @@ class Server(object):
 @api.route('/datashape', methods=['GET'])
 @cross_origin(origins='*', methods=['GET'])
 @authorization
+@_logging
 def shape():
     return pprint(discover(_get_data()), width=0)
 
@@ -508,7 +532,9 @@ accepted_mimetypes = {'application/vnd.blaze+{}'.format(x.name): x.name for x
 @cross_origin(origins='*', methods=['POST', 'HEAD', 'OPTIONS'])
 @authorization
 @check_request
+@_logging
 def compserver(payload, serial):
+    app = flask.current_app
     (allow_profiler,
      default_profiler_output,
      profile_by_default) = _get_profiler_info()
@@ -541,7 +567,7 @@ def compserver(payload, serial):
 
         @response_construction_context_stack.callback
         def log_time(start=time()):
-            flask.current_app.logger.info('compute expr: %s\ntotal time (s): %.3f',
+            app.logger.info('compute expr: %s\ntotal time (s): %.3f',
                                           expr,
                                           time() - start)
 
@@ -562,10 +588,13 @@ def compserver(payload, serial):
                                         expr.dshape,
                                         odo_kwargs)
         except NotImplementedError as e:
-            return ("Computation not supported:\n%s" % e, RC.NOT_IMPLEMENTED)
+            error_msg = "Computation not supported:\n%s\n%s" % (e, traceback.format_exc())
+            app.logger.error(error_msg)
+            return (error_msg, RC.NOT_IMPLEMENTED)
         except Exception as e:
-            return ("Computation failed with message:\n%s: %s" % (type(e).__name__, e),
-                    RC.INTERNAL_SERVER_ERROR)
+            error_msg = "Computation failed with message:\n%s: %s\n%s" % (type(e).__name__, e, traceback.format_exc())
+            app.logger.error(error_msg)
+            return (error_msg, RC.INTERNAL_SERVER_ERROR)
 
         response = {'datashape': pprint(expr.dshape, width=0),
                     'data': serial.data_dumps(result),
@@ -596,6 +625,7 @@ def compserver(payload, serial):
 @cross_origin(origins='*', methods=['POST', 'HEAD', 'OPTIONS'])
 @authorization
 @check_request
+@_logging
 def addserver(payload, serial):
     """Add a data resource to the server.
 

--- a/blaze/server/spider.py
+++ b/blaze/server/spider.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
-
 from __future__ import absolute_import
 
 import os
-import sys
 import argparse
 import importlib
 
@@ -169,9 +167,10 @@ def _parse_args():
     p.add_argument('-D', '--debug', action='store_true',
                    help='Start the Flask server in debug mode')
     p.add_argument('--log-file', type=str, default=None,
-                   help='Log file for warnings and errors.')
+                   help='Log filename -- if not set, logs to standard output.')
     p.add_argument('--log-level', type=str, default='WARNING',
-                   help='Logging level.')
+                   help=('Level of output for logs. Set to DEBUG for most'
+                         'verbose, or ERROR for least.'))
     args = p.parse_args()
     if not (args.path or args.allow_dynamic_addition):
         msg = "No YAML file provided and --allow-dynamic-addition flag not set."

--- a/blaze/server/spider.py
+++ b/blaze/server/spider.py
@@ -168,6 +168,10 @@ def _parse_args():
                    help='Allow dynamically adding datasets to the server')
     p.add_argument('-D', '--debug', action='store_true',
                    help='Start the Flask server in debug mode')
+    p.add_argument('--log-file', type=str, default=None,
+                   help='Log file for warnings and errors.')
+    p.add_argument('--log-level', type=str, default='WARNING',
+                   help='Logging level.')
     args = p.parse_args()
     if not (args.path or args.allow_dynamic_addition):
         msg = "No YAML file provided and --allow-dynamic-addition flag not set."
@@ -186,7 +190,10 @@ def _main():
                               relative_to_yaml_dir=args.yaml_dir)
     else:
         resources = {}
-    server = Server(resources, allow_add=args.allow_dynamic_addition)
+    server = Server(resources,
+                    allow_add=args.allow_dynamic_addition,
+                    logfile=args.log_file,
+                    loglevel=args.log_level)
     server.run(host=args.host, port=args.port, debug=args.debug)
 
 

--- a/blaze/server/tests/test_server.py
+++ b/blaze/server/tests/test_server.py
@@ -6,6 +6,7 @@ pytest.importorskip('flask.ext.cors')
 
 from base64 import b64encode
 from copy import copy
+from io import StringIO
 
 import datashape
 from datashape.util.testing import assert_dshape_equal
@@ -106,6 +107,20 @@ def temp_add_server(request):
     s.app.testing = True
     with s.app.test_client() as c:
         yield c
+
+
+@pytest.yield_fixture(params=[None, tdata])
+def temp_server_with_excfmt(request):
+    """With a custom log exception formatter"""
+    data = request.param
+    log_format_exc = lambda tb: 'CUSTOM TRACEBACK'
+    stream = StringIO()
+    s = Server(copy(data), formats=all_formats, allow_add=True,
+               logfile=stream, log_exception_formatter=log_format_exc)
+    s.app.testing = True
+    with s.app.test_client() as client:
+        yield (client, stream)
+
 
 
 @pytest.yield_fixture
@@ -660,6 +675,19 @@ def test_add_default_not_allowed(temp_server, serial):
                                  data=blob)
     assert 'NOT FOUND' in response1.status
     assert response1.status_code == RC.NOT_FOUND
+
+
+@pytest.mark.parametrize('serial', all_formats)
+def test_log_format_exc(temp_server_with_excfmt, serial):
+    expr = t.dumb.sort()
+    bad_query = {'expr': to_tree(expr)}
+
+    server, log_stream = temp_server_with_excfmt
+    result = server.post('/compute', headers=mimetype(serial),
+                         data=serial.dumps(bad_query))
+
+    assert 'CUSTOM TRACEBACK' in log_stream.getvalue()
+
 
 
 @pytest.mark.parametrize('serial', all_formats)

--- a/blaze/server/tests/test_server.py
+++ b/blaze/server/tests/test_server.py
@@ -6,7 +6,12 @@ pytest.importorskip('flask.ext.cors')
 
 from base64 import b64encode
 from copy import copy
-from io import StringIO
+# Python 2.7's `io.StringIO` doesn't behave as expected
+# with str values
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 import datashape
 from datashape.util.testing import assert_dshape_equal


### PR DESCRIPTION
Takes #1492 and adds to it, defaulting logging to `sys.stdout` and adding documentation strings for the new parameters. 

As far as basic logging of output this is already done, however we will probably want to add more specific logging for different scenarios -- this can be in this PR or in a future update.