### PR TITLE
Fix Pandas `string` and `datetime` coercions

### DIFF
--- a/blaze/compute/pandas.py
+++ b/blaze/compute/pandas.py
@@ -753,6 +753,12 @@ def compute_up(expr, data, **kwargs):
 
 @dispatch(Coerce, (Series, DaskSeries))
 def compute_up(expr, data, **kwargs):
+    if datashape.dshape(expr.to) in {datashape.string,
+                                     datashape.Option(datashape.string)}:
+        return data.astype(str)
+    elif datashape.dshape(expr.to) in {datashape.datetime_,
+                                       datashape.Option(datashape.datetime_)}:
+        return data.astype(np.datetime64)
     return data.astype(to_numpy_dtype(expr.schema))
 
 

--- a/blaze/compute/tests/test_pandas_compute.py
+++ b/blaze/compute/tests/test_pandas_compute.py
@@ -925,6 +925,19 @@ def test_coerce_series():
     assert_series_equal(result, expected)
 
 
+@pytest.mark.parametrize('d, tp, ptp', [(list(range(10)), 'string', str),
+                                        (list(range(10)) + [None], '?string', str),
+                                        (['2010-01-01'], 'datetime', np.datetime64),
+                                        (['2010-01-01', None, ''], '?datetime', np.datetime64)])
+def test_coerce_series_string_datetime(d, tp, ptp):
+    s = pd.Series(d, name='a')
+    e = symbol('t', discover(s)).coerce(to=tp)
+    assert e.schema == dshape(tp)
+    result = compute(e, s)
+    expected = s.astype(ptp)
+    assert_series_equal(result, expected)
+
+
 def test_concat_arr():
     s_data = Series(np.arange(15))
     t_data = Series(np.arange(15, 30))

--- a/docs/source/whatsnew/0.10.2.txt
+++ b/docs/source/whatsnew/0.10.2.txt
@@ -47,6 +47,8 @@ Bug Fixes
   before lookups inside the ``names`` namespace (:issue:`1516`).
 * Perform more input validation for ``sort()`` expression arguments
   (:issue:`1517`).
+* Fixes issue with string and datetime coercions on Pandas objects
+  (:issue:`1519` :issue:`1524`).
 
 Miscellaneous
 ~~~~~~~~~~~~~


### PR DESCRIPTION
Closes #1519.

Added tests for both str and datetime, which required special casing both in the Pandas `Coerce` dispatch.