### PR TITLE
Memoize subs.

### DIFF
--- a/blaze/expr/core.py
+++ b/blaze/expr/core.py
@@ -15,7 +15,7 @@ from toolz import unique, concat, first
 
 from ..compatibility import _strtypes
 from ..dispatch import dispatch
-from ..utils import ordered_intersect
+from ..utils import ordered_intersect, memoize_mutable
 
 __all__ = ['Node', 'path', 'common_subexpression', 'eval_str']
 
@@ -404,6 +404,7 @@ def subterms(x):
     yield x
 
 
+@memoize_mutable
 def subs(o, d):
     """ Substitute values within data structure
 

--- a/blaze/expr/core.py
+++ b/blaze/expr/core.py
@@ -15,7 +15,7 @@ from toolz import unique, concat, first
 
 from ..compatibility import _strtypes
 from ..dispatch import dispatch
-from ..utils import ordered_intersect, memoize_mutable
+from ..utils import ordered_intersect, memoize_obj_mapping
 
 __all__ = ['Node', 'path', 'common_subexpression', 'eval_str']
 
@@ -404,7 +404,7 @@ def subterms(x):
     yield x
 
 
-@memoize_mutable
+@memoize_obj_mapping
 def subs(o, d):
     """ Substitute values within data structure
 

--- a/blaze/utils.py
+++ b/blaze/utils.py
@@ -274,18 +274,25 @@ def parameter_space(*args):
     )))
 
 
-def memoize_mutable(fn):
+def memoize_obj_mapping(fn):
+    """Memoize fn with the argument types (object, Mapping). The arguments
+       may be mutable.
+    """
     memo = {}
     @functools.wraps(fn)
-    def inner(*args):
+    def inner(o, d):
+        key = (o, tuple(d.items()))
         try:
-            s = dumps(args, HIGHEST_PROTOCOL)
-        except (TypeError, AttributeError, PicklingError):
-            s = None
-        if s is None:
-            return fn(*args)
+            hash(key)
+        except TypeError:
+            try:
+                key = dumps((o, d), HIGHEST_PROTOCOL)
+            except (TypeError, AttributeError, PicklingError):
+                key = None
+        if key is None:
+            return fn(o, d)
         else:
-            if not s in memo:
-                memo[s] = fn(*args)
-            return memo[s]
+            if not key in memo:
+                memo[key] = fn(o, d)
+            return memo[key]
     return inner


### PR DESCRIPTION
This patch improves the performance of `subs()` for large or more complex trees (see  #1518).

Simple example (10x speedup):

``` python
from blaze.expr.core import subs
import time

def mktree(d):
    if d <= 0:
        return []
    return [1, 2, [mktree(d-1)], [mktree(d-1)]]

t1 = mktree(16)

start = time.time()
t2 = subs(t1, {1: 2})
end = time.time()
print(end-start)
```
