### PR TITLE
Add datetime functions to 'dt' namespace.

### DIFF
--- a/blaze/compute/pandas.py
+++ b/blaze/compute/pandas.py
@@ -57,6 +57,7 @@ from ..expr import (
     BinOp,
     Broadcast,
     By,
+    Ceil,
     Coalesce,
     Coerce,
     Concat,
@@ -66,6 +67,7 @@ from ..expr import (
     ElemWise,
     Expr,
     Field,
+    Floor,
     Head,
     Interp,
     IsIn,
@@ -80,11 +82,14 @@ from ..expr import (
     ReLabel,
     Reduction,
     Replace,
+    Round,
     Sample,
+    seconds,
     Selection,
     Shift,
     Slice,
     Sort,
+    strftime,
     Summary,
     Tail,
     UTCFromTimestamp,
@@ -104,6 +109,7 @@ from ..expr import (
     StrFind,
     StrSlice,
     SliceReplace,
+    total_seconds,
 )
 
 __all__ = []
@@ -734,6 +740,12 @@ def compute_up(expr, s, **kwargs):
     return get_date_attr(s, expr.attr, expr._name)
 
 
+@dispatch(total_seconds, Series)
+def compute_up(expr, s, **kwargs):
+    result = s.dt.total_seconds()
+    result.name = expr._name
+    return result
+
 @dispatch(UTCFromTimestamp, Series)
 def compute_up(expr, s, **kwargs):
     return pd.datetools.to_datetime(s * 1e9, utc=True)
@@ -743,6 +755,26 @@ def compute_up(expr, s, **kwargs):
 def compute_up(expr, s, **kwargs):
     return get_date_attr(s, 'microsecond',
                          '%s_millisecond' % expr._child._name) // 1000
+
+
+@dispatch(Round, Series)
+def compute_up(expr, data, **kwargs):
+    return data.dt.round(expr.freq)
+
+
+@dispatch(Ceil, Series)
+def compute_up(expr, data, **kwargs):
+    return data.dt.ceil(expr.freq)
+
+
+@dispatch(Floor, Series)
+def compute_up(expr, data, **kwargs):
+    return data.dt.floor(expr.freq)
+
+
+@dispatch(strftime, Series)
+def compute_up(expr, data, **kwargs):
+    return data.dt.strftime(expr.format)
 
 
 @dispatch(Slice, (DataFrame, Series))

--- a/blaze/compute/tests/test_pandas_compute.py
+++ b/blaze/compute/tests/test_pandas_compute.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, date, time
 
 import numpy as np
 
@@ -845,6 +845,68 @@ def test_datetime_access():
         expr = getattr(t.when, attr)
         assert_series_equal(compute(expr, df),
                             Series([1, 1, 1], name=expr._name))
+
+
+@pytest.mark.parametrize('attr, args, expected',
+                         [('date', [], date(2016, 6, 5)),
+                          ('year', [], 2016),
+                          ('month', [], 6),
+                          ('day', [], 5),
+                          ('time', [], time(13, 32, 1)),
+                          ('hour', [], 13),
+                          ('minute', [], 32),
+                          ('second', [], 1),
+                          ('millisecond', [], 0),
+                          ('microsecond', [], 0),
+                          ('nanosecond', [], 0),
+                          ('week', [], 22),
+                          ('weekday', [], 6),
+                          ('weekday_name', [], 'Sunday'),
+                          ('daysinmonth', [], 30),
+                          ('weekofyear', [], 22),
+                          ('dayofyear', [], 157),
+                          ('dayofweek', [], 6),
+                          ('quarter', [], 2),
+                          ('is_month_start', [], False),
+                          ('is_month_end', [], False),
+                          ('is_quarter_start', [], False),
+                          ('is_quarter_end', [], False),
+                          ('is_year_start', [], False),
+                          ('is_year_end', [], False),
+                          ('days_in_month', [], 30),
+                          ('strftime', ['%Y-%m-%d'], '2016-06-05'),
+                         ])
+def test_dt_namespace(attr, args, expected):
+    df = DataFrame({'when': [datetime(2016, 6, 5, 13, 32, 1)]})
+    t = symbol('t', 'var * {when: datetime}')
+    expr = getattr(t.when.dt, attr)(*args)
+    assert_series_equal(compute(expr, df), Series(expected, name=expr._name))
+
+
+@pytest.mark.parametrize('attr, args, expected',
+                         [('days', [], 7),
+                          ('nanoseconds', [], 0),
+                          ('seconds', [], 0),
+                          ('total_seconds', [], 604800.),
+                         ])
+def test_td_namespace(attr, args, expected):
+    """timedelta functions"""
+    df = DataFrame({'span': [timedelta(7)]})
+    t = symbol('t', 'var * {span: timedelta}')
+    expr = getattr(t.span.dt, attr)(*args)
+    assert_series_equal(compute(expr, df), Series(expected, name=expr._name))
+
+
+@pytest.mark.parametrize('op, freq, expected',
+                         [('round', 's', datetime(2016, 6, 5, 13, 32, 1)),
+                          ('round', 'h', datetime(2016, 6, 5, 14, 0, 0)),
+                          ('floor', 'h', datetime(2016, 6, 5, 13, 0, 0)),
+                          ('ceil', 'h', datetime(2016, 6, 5, 14, 0, 0))])
+def test_dt_round(op, freq, expected):
+    df = DataFrame({'when': [datetime(2016, 6, 5, 13, 32, 1)]})
+    t = symbol('t', 'var * {when: datetime}')
+    expr = getattr(t.when.dt, op)(freq)
+    assert_series_equal(compute(expr, df), Series(expected, name=expr._name))
 
 
 def test_frame_slice():

--- a/blaze/expr/datetime.py
+++ b/blaze/expr/datetime.py
@@ -30,7 +30,8 @@ class DateTime(ElemWise):
         return '%s.%s' % (str(self._child), type(self).__name__.lower())
 
     def _schema(self):
-        return dshape(self._dtype)
+        ds = dshape(self._dtype)
+        return ds if not isinstance(self._child.schema.measure, datashape.Option) else datashape.Option(ds)
 
     @property
     def _name(self):

--- a/blaze/expr/datetime.py
+++ b/blaze/expr/datetime.py
@@ -7,9 +7,12 @@ from datashape import dshape, isdatelike, isnumeric
 
 
 __all__ = ['DateTime', 'Date', 'date', 'Year', 'year', 'Month', 'month', 'Day',
-           'day', 'Hour', 'hour', 'Minute', 'minute', 'Second', 'second',
-           'Millisecond', 'millisecond', 'Microsecond', 'microsecond', 'Date',
-           'date', 'Time', 'time', 'UTCFromTimestamp', 'DateTimeTruncate']
+           'day', 'days', 'Hour', 'hour', 'Minute', 'minute', 'Second', 'second',
+           'Millisecond', 'millisecond', 'Microsecond', 'microsecond', 'nanosecond',
+           'Date',
+           'date', 'Time', 'time', 'week', 'nanoseconds', 'seconds', 'total_seconds',
+           'UTCFromTimestamp', 'DateTimeTruncate',
+           'Ceil', 'Floor', 'Round', 'strftime']
 
 
 class DateTime(ElemWise):
@@ -119,6 +122,27 @@ def utcfromtimestamp(expr):
     return UTCFromTimestamp(expr)
 
 
+class nanosecond(DateTime): _dtype = datashape.int64
+class week(DateTime): _dtype = datashape.int64
+class weekday(DateTime): _dtype = datashape.int64
+class weekday_name(DateTime): _dtype = datashape.string
+class daysinmonth(DateTime): _dtype = datashape.int64
+class weekofyear(DateTime): _dtype = datashape.int64
+class dayofyear(DateTime): _dtype = datashape.int64
+class dayofweek(DateTime): _dtype = datashape.int64
+class quarter(DateTime): _dtype = datashape.int64
+class is_month_start(DateTime): _dtype = datashape.bool_
+class is_month_end(DateTime): _dtype = datashape.bool_
+class is_quarter_start(DateTime): _dtype = datashape.bool_
+class is_quarter_end(DateTime): _dtype = datashape.bool_
+class is_year_start(DateTime): _dtype = datashape.bool_
+class is_year_end(DateTime): _dtype = datashape.bool_
+class days_in_month(DateTime): _dtype = datashape.int64
+
+class strftime(ElemWise):
+    _arguments = '_child', 'format'
+    schema = datashape.string
+
 units = (
     'year',
     'month',
@@ -222,10 +246,149 @@ def truncate(expr, *args, **kwargs):
     return DateTimeTruncate(expr, measure, normalize_time_unit(unit))
 
 
+class UnaryDateTimeFunction(ElemWise):
+
+    """DateTime function that only takes a single argument."""
+    _arguments = '_child'
+
+
+class Round(ElemWise):
+    _arguments = '_child', 'freq'
+
+    @property
+    def schema(self):
+        return self._child.schema
+
+
+class Floor(ElemWise):
+    _arguments = '_child', 'freq'
+
+    @property
+    def schema(self):
+        return self._child.schema
+
+
+class Ceil(ElemWise):
+    _arguments = '_child', 'freq'
+
+    @property
+    def schema(self):
+        return self._child.schema
+
+
+class dt_ns(object):
+
+    def __init__(self, field):
+        self.field = field
+
+    def year(self):
+        return year(self.field)
+    def month(self):
+        return month(self.field)
+    def day(self):
+        return day(self.field)
+    def hour(self):
+        return hour(self.field)
+    def minute(self):
+        return minute(self.field)
+    def date(self):
+        return date(self.field)
+    def time(self):
+        return time(self.field)
+    def second(self):
+        return second(self.field)
+    def millisecond(self):
+        return millisecond(self.field)
+    def microsecond(self):
+        return microsecond(self.field)
+    def nanosecond(self):
+        return nanosecond(self.field)
+    def weekday(self):
+        return weekday(self.field)
+    def weekday_name(self):
+        return weekday_name(self.field)
+    def daysinmonth(self):
+        return daysinmonth(self.field)
+    def weekofyear(self):
+        return weekofyear(self.field)
+    def dayofyear(self):
+        return dayofyear(self.field)
+    def dayofweek(self):
+        return dayofweek(self.field)
+    def quarter(self):
+        return quarter(self.field)
+    def is_month_start(self):
+        return is_month_start(self.field)
+    def is_month_end(self):
+        return is_month_end(self.field)
+    def is_quarter_start(self):
+        return is_quarter_start(self.field)
+    def is_quarter_end(self):
+        return is_quarter_end(self.field)
+    def is_year_start(self):
+        return is_year_start(self.field)
+    def is_year_end(self):
+        return is_year_end(self.field)
+    def days_in_month(self):
+        return days_in_month(self.field)
+    def strftime(self, format):
+        return strftime(self.field, format)
+    def truncate(self, *args, **kwargs):
+        return truncate(self.field, *args, **kwargs)
+    def round(self, freq):
+        return Round(self.field, freq)
+    def floor(self, freq):
+        return Floor(self.field, freq)
+    def ceil(self, freq):
+        return Ceil(self.field, freq)
+    def week(self):
+        return week(self.field)
+
+class dt(object):
+
+    __name__ = 'dt'
+
+    def __get__(self, obj, type=None):
+        return dt_ns(obj) if obj is not None else self
+
+
+class days(DateTime): _dtype = datashape.int64
+class nanoseconds(DateTime): _dtype = datashape.int64
+class seconds(DateTime): _dtype = datashape.int64
+class total_seconds(DateTime): _dtype = datashape.int64
+
+
+class td_ns(object):
+
+    def __init__(self, field):
+        self.field = field
+
+    def days(self): return days(self.field)
+    def nanoseconds(self): return nanoseconds(self.field)
+    def seconds(self): return seconds(self.field)
+    def total_seconds(self): return total_seconds(self.field)
+
+
+class td(object):
+
+    # pandas uses the same 'dt' name for
+    # DateTimeProperties and TimedeltaProperties.
+    __name__ = 'dt'
+
+    def __get__(self, obj, type=None):
+        return td_ns(obj) if obj is not None else self
+
+
+def isdeltalike(ds):
+    from datashape.coretypes import timedelta_
+    return ds == timedelta_
+
 schema_method_list.extend([
     (isdatelike, set([year, month, day, hour, minute, date, time, second,
-                      millisecond, microsecond, truncate])),
-    (isnumeric, set([utcfromtimestamp]))
+                      millisecond, microsecond, truncate,
+                      dt()])),
+    (isnumeric, set([utcfromtimestamp])),
+    (isdeltalike, set([td()]))
 ])
 
 method_properties |= set([year, month, day, hour, minute, second, millisecond,

--- a/blaze/expr/tests/test_datetime.py
+++ b/blaze/expr/tests/test_datetime.py
@@ -1,6 +1,5 @@
 from blaze.expr import symbol
 import blaze.expr.datetime as bdt
-#from blaze.expr.datetime import isdatelike
 from blaze.compatibility import builtins
 from datashape import dshape
 

--- a/blaze/expr/tests/test_datetime.py
+++ b/blaze/expr/tests/test_datetime.py
@@ -1,5 +1,6 @@
 from blaze.expr import symbol
-from blaze.expr.datetime import isdatelike
+import blaze.expr.datetime as bdt
+#from blaze.expr.datetime import isdatelike
 from blaze.compatibility import builtins
 from datashape import dshape
 
@@ -43,9 +44,9 @@ def test_utcfromtimestamp():
 
 
 def test_isdatelike():
-    assert not isdatelike('int32')
-    assert isdatelike('?date')
-    assert not isdatelike('{is_outdated: bool}')
+    assert not bdt.isdatelike('int32')
+    assert bdt.isdatelike('?date')
+    assert not bdt.isdatelike('{is_outdated: bool}')
 
 
 def test_truncate_names():
@@ -76,3 +77,43 @@ def test_attributes(attr):
     t = symbol('t', 'var * datetime')
     assert getattr(t, attr).dshape is not None
     assert getattr(t, attr)._child is t
+
+
+def test_dt_namespace():
+    t = symbol('t', 'var * {when: datetime}')
+    assert bdt.Ceil(t.when, 's').isidentical(t.when.dt.ceil('s'))
+    assert bdt.date(t.when).isidentical(t.when.dt.date())
+    assert bdt.day(t.when).isidentical(t.when.dt.day())
+    assert bdt.dayofweek(t.when).isidentical(t.when.dt.dayofweek())
+    assert bdt.dayofyear(t.when).isidentical(t.when.dt.dayofyear())
+    assert bdt.days_in_month(t.when).isidentical(t.when.dt.days_in_month())
+    assert bdt.Floor(t.when, 's').isidentical(t.when.dt.floor('s'))
+    assert bdt.hour(t.when).isidentical(t.when.dt.hour())
+    assert bdt.is_month_end(t.when).isidentical(t.when.dt.is_month_end())
+    assert bdt.is_month_start(t.when).isidentical(t.when.dt.is_month_start())
+    assert bdt.is_quarter_end(t.when).isidentical(t.when.dt.is_quarter_end())
+    assert bdt.is_quarter_start(t.when).isidentical(t.when.dt.is_quarter_start())
+    assert bdt.is_year_end(t.when).isidentical(t.when.dt.is_year_end())
+    assert bdt.is_year_start(t.when).isidentical(t.when.dt.is_year_start())
+    assert bdt.microsecond(t.when).isidentical(t.when.dt.microsecond())
+    assert bdt.millisecond(t.when).isidentical(t.when.dt.millisecond())
+    assert bdt.minute(t.when).isidentical(t.when.dt.minute())
+    assert bdt.month(t.when).isidentical(t.when.dt.month())
+    assert bdt.nanosecond(t.when).isidentical(t.when.dt.nanosecond())
+    assert bdt.Round(t.when, 's').isidentical(t.when.dt.round('s'))
+    assert bdt.quarter(t.when).isidentical(t.when.dt.quarter())
+    assert bdt.second(t.when).isidentical(t.when.dt.second())
+    assert bdt.strftime(t.when, 'format').isidentical(t.when.dt.strftime('format'))
+    assert bdt.time(t.when).isidentical(t.when.dt.time())
+    assert bdt.truncate(t.when, days=2).isidentical(t.when.dt.truncate(days=2))
+    assert bdt.week(t.when).isidentical(t.when.dt.week())
+    assert bdt.weekday(t.when).isidentical(t.when.dt.weekday())
+    assert bdt.weekofyear(t.when).isidentical(t.when.dt.weekofyear())
+    assert bdt.year(t.when).isidentical(t.when.dt.year())
+
+def test_td_namespace():
+    t = symbol('t', 'var * {span: timedelta}')
+    assert bdt.nanoseconds(t.span).isidentical(t.span.dt.nanoseconds())
+    assert bdt.seconds(t.span).isidentical(t.span.dt.seconds())
+    assert bdt.total_seconds(t.span).isidentical(t.span.dt.total_seconds())
+

--- a/blaze/server/tests/test_server.py
+++ b/blaze/server/tests/test_server.py
@@ -606,7 +606,7 @@ def test_minute_query(test, serial):
                        data=serial.dumps(query))
     expected = {'data': [0, 0],
                 'names': ['when_minute'],
-                'datashape': '2 * int64'}
+                'datashape': '2 * ?int64'}
     assert result.status_code == RC.OK
     resp = serial.loads(result.data)
     assert list(serial.data_loads(resp['data'])) == expected['data']

--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -2,6 +2,16 @@
 Release Notes
 =============
 
+.. include:: whatsnew/0.11.0.txt
+
+.. include:: whatsnew/0.10.2.txt
+
+.. include:: whatsnew/0.10.1.txt
+
+.. include:: whatsnew/0.10.0.txt
+
+.. include:: whatsnew/0.9.1.txt
+
 .. include:: whatsnew/0.9.0.txt
 
 .. include:: whatsnew/0.8.3.txt

--- a/docs/source/whatsnew/0.10.0.txt
+++ b/docs/source/whatsnew/0.10.0.txt
@@ -1,7 +1,7 @@
-Release |version|
------------------
+Release 0.10.0
+--------------
 
-:Release: |version|
+:Release: 0.10.0
 :Date: TBD
 
 New Expressions

--- a/docs/source/whatsnew/0.10.1.txt
+++ b/docs/source/whatsnew/0.10.1.txt
@@ -1,7 +1,7 @@
-Release |version|
------------------
+Release 0.10.1
+--------------
 
-:Release: |version|
+:Release: 0.10.1
 :Date: TBD
 
 New Expressions

--- a/docs/source/whatsnew/0.11.0.txt
+++ b/docs/source/whatsnew/0.11.0.txt
@@ -8,13 +8,17 @@ New Expressions
 
 * Many new string utility expressions were added that follow the Pandas
   vectorized string methods API closely
-  `http://pandas.pydata.org/pandas-docs/stable/text.html#text-string-methods`_.
+  `<http://pandas.pydata.org/pandas-docs/stable/text.html#text-string-methods>`_.
   These are gathered under the ``.str`` sub-namespace, allowing the user to
   say::
 
     t.col.str.lower()
 
   to compute a new column with the string contents lowercased.
+
+* Likewise, many new datetime utility expressions were added to the ``.dt``
+  sub-namespace, following Pandas vectorized datetime methods API
+  `<http://pandas.pydata.org/pandas-docs/stable/timeseries.html>`_.
 
 Improved Expressions
 ~~~~~~~~~~~~~~~~~~~~
@@ -39,7 +43,17 @@ None
 API Changes
 ~~~~~~~~~~~
 
-None
+* The following functions were deprecated in favor of equivalent functions without the `str_` name prefix:
+
+  ======================================  ===================================
+  deprecated function                     replacement function
+  ======================================  ===================================
+  :func:`~blaze.expr.strings.str_len`     :func:`~blaze.expr.strings.len`
+  :func:`~blaze.expr.strings.str_upper`   :func:`~blaze.expr.strings.upper`
+  :func:`~blaze.expr.strings.str_lower`   :func:`~blaze.expr.strings.lower`
+  :func:`~blaze.expr.strings.str_cat`     :func:`~blaze.expr.strings.cat`
+  ======================================  ===================================
+
 
 Bug Fixes
 ~~~~~~~~~

--- a/docs/source/whatsnew/0.9.0.txt
+++ b/docs/source/whatsnew/0.9.0.txt
@@ -1,7 +1,7 @@
-Release |version|
------------------
+Release 0.9.0
+-------------
 
-:Release: |version|
+:Release: 0.9.0
 :Date: December 17th, 2015
 
 New Expressions

--- a/docs/source/whatsnew/0.9.1.txt
+++ b/docs/source/whatsnew/0.9.1.txt
@@ -1,7 +1,7 @@
-Release |version|
------------------
+Release 0.9.1
+-------------
 
-:Release: |version|
+:Release: 0.9.1
 :Date: December 17th, 2015
 
 New Expressions


### PR DESCRIPTION
This PR adds various functions to the 'dt' namespace.
To mimic pandas, there are actually two distinct namespaces, one for `datetime` types, the other for `timedelta` types, both named `dt`.