### PR TITLE
Replace chunks backend with dask for CSV reading.

### DIFF
--- a/blaze/compute/csv.py
+++ b/blaze/compute/csv.py
@@ -7,10 +7,10 @@ import pandas as pd
 import numpy as np
 from collections import Iterator, Iterable
 from odo import into, Temp
-from odo.chunks import chunks
 from odo.backends.csv import CSV
 from odo.backends.url import URL
 from multipledispatch import MDNotImplementedError
+import dask.dataframe as dd
 
 from ..dispatch import dispatch
 from ..expr import Expr, Head, ElemWise, Distinct, Symbol, Projection, Field
@@ -20,6 +20,7 @@ from ..expr.split import split
 from .core import compute
 from ..expr.optimize import lean_projection
 from .pmap import get_default_pmap
+from warnings import warn
 
 
 __all__ = ['optimize', 'pre_compute', 'compute_chunk', 'compute_down']
@@ -31,16 +32,21 @@ def optimize(expr, _):
 
 
 @dispatch(Expr, CSV)
-def pre_compute(expr, data, comfortable_memory=None, chunksize=2**18, **kwargs):
+def pre_compute(expr, data, comfortable_memory=None, chunksize=None, blocksize=None, **kwargs):
     comfortable_memory = comfortable_memory or min(1e9, available_memory() / 4)
 
     kwargs = dict()
 
     # Chunk if the file is large
     if os.path.getsize(data.path) > comfortable_memory:
-        kwargs['chunksize'] = chunksize
+        do_chunk = True
+        if chunksize is not None:
+            warn("Deprecation warning: chunksize keyword renamed to blocksize")
+            blocksize = chunksize
+        if blocksize is not None:
+            kwargs['blocksize'] = blocksize
     else:
-        chunksize = None
+        do_chunk = False
 
     # Insert projection into read_csv
     oexpr = optimize(expr, data)
@@ -51,8 +57,8 @@ def pre_compute(expr, data, comfortable_memory=None, chunksize=2**18, **kwargs):
         # PY2 Pandas bug with strings / unicode objects.
         kwargs['usecols'] = list(map(str, pth[-2].fields))
 
-    if chunksize:
-        return into(chunks(pd.DataFrame), data, dshape=leaf.dshape, **kwargs)
+    if do_chunk:
+        return dd.read_csv(data.path, **kwargs)
     else:
         return into(pd.DataFrame, data, dshape=leaf.dshape, **kwargs)
 

--- a/blaze/compute/pandas.py
+++ b/blaze/compute/pandas.py
@@ -571,7 +571,7 @@ pdsort = getattr(
 )
 
 
-@dispatch(Sort, (DataFrame, DaskDataFrame))
+@dispatch(Sort, DataFrame)
 def compute_up(t, df, **kwargs):
     return pdsort(df, t.key, ascending=t.ascending)
 

--- a/blaze/compute/tests/test_csv_compute.py
+++ b/blaze/compute/tests/test_csv_compute.py
@@ -11,7 +11,7 @@ from toolz import first
 from collections import Iterator
 from odo import odo
 from odo.chunks import chunks
-
+import dask.dataframe
 
 def test_pre_compute_on_small_csv_gives_dataframe():
     csv = CSV(example('iris.csv'))
@@ -19,11 +19,11 @@ def test_pre_compute_on_small_csv_gives_dataframe():
     assert isinstance(pre_compute(s.species, csv), (Series, DataFrame))
 
 
-def test_pre_compute_on_large_csv_gives_chunked_reader():
+def test_pre_compute_on_large_csv_gives_dask_reader():
     csv = CSV(example('iris.csv'))
     s = symbol('s', discover(csv))
     assert isinstance(pre_compute(s.species, csv, comfortable_memory=10),
-                      (chunks(pd.DataFrame), pd.io.parsers.TextFileReader))
+                      dask.dataframe.DataFrame)
 
 
 def test_pre_compute_with_head_on_large_csv_yields_iterator():
@@ -37,25 +37,23 @@ def test_compute_chunks_on_single_csv():
     csv = CSV(example('iris.csv'))
     s = symbol('s', discover(csv))
     expr = s.sepal_length.max()
-    assert compute(expr, {s: csv}, comfortable_memory=10, chunksize=50) == 7.9
+    assert compute(expr, {s: csv}, comfortable_memory=10, blocksize=50) == 7.9
 
 
-def test_pre_compute_with_projection_projects_on_data_frames():
+def test_compute_with_projection_projects_on_data_frames():
     csv = CSV(example('iris.csv'))
     s = symbol('s', discover(csv))
-    result = pre_compute(s[['sepal_length', 'sepal_width']].distinct(),
-                         csv, comfortable_memory=10)
-    assert set(first(result).columns) == \
-            set(['sepal_length', 'sepal_width'])
+    result = compute(s[['sepal_length', 'sepal_width']],
+                     csv, comfortable_memory=10)
+    assert set(result.columns) == set(['sepal_length', 'sepal_width'])
 
 
-def test_pre_compute_calls_lean_projection():
+def test_compute_calls_lean_projection():
     csv = CSV(example('iris.csv'))
     s = symbol('s', discover(csv))
-    result = pre_compute(s.sort('sepal_length').species,
-                         csv, comfortable_memory=10)
-    assert set(first(result).columns) == \
-            set(['sepal_length', 'species'])
+    result = compute(s[s.sepal_length > 5.0].species,
+                     csv, comfortable_memory=10)
+    assert len(result) == 118
 
 
 def test_unused_datetime_columns():

--- a/blaze/compute/tests/test_csv_compute.py
+++ b/blaze/compute/tests/test_csv_compute.py
@@ -51,9 +51,9 @@ def test_compute_with_projection_projects_on_data_frames():
 def test_compute_calls_lean_projection():
     csv = CSV(example('iris.csv'))
     s = symbol('s', discover(csv))
-    result = compute(s[s.sepal_length > 5.0].species,
-                     csv, comfortable_memory=10)
-    assert len(result) == 118
+    result = pre_compute(s[s.sepal_length > 5.0].species,
+                         csv, comfortable_memory=10)
+    assert set(result.columns) == set(['sepal_length', 'species'])
 
 
 def test_unused_datetime_columns():


### PR DESCRIPTION
This implements the simple backend replacment. It was tested against dask master. While explicitly specifying a blocksize affects performance, even the default is (now) better than performance with the chunks backend.

This change may obsolete a number of other functions that are no longer reachable, so a little more cleanup may be warranted.
I'm also not quite sure how much testing this needs.