### PR TITLE
Issue #1552: Fix method discovery (foreign key)

### DIFF
--- a/blaze/expr/expressions.py
+++ b/blaze/expr/expressions.py
@@ -220,9 +220,13 @@ class Expr(Node):
         except AttributeError:
             fields = dict(zip(map(valid_identifier, self.fields), self.fields))
 
+            measure = self.dshape.measure
+            if isinstance(measure, datashape.Map): # Foreign key
+                measure = measure.key
+
             # prefer the method if there's a field with the same name
             methods = toolz.merge(
-                schema_methods(self.dshape.measure),
+                schema_methods(measure),
                 dshape_methods(self.dshape)
             )
             if key in methods:


### PR DESCRIPTION
This fixes the method discovery if the datashape represents a foreign key.  It further entrenches the assumption that datashape.Map *always* represents a foreign key, see e.g.

https://github.com/blaze/blaze/blob/master/blaze/expr/expressions.py#L176

Compare with the datashape docs ("meant to be useful outside of that context "):

https://github.com/blaze/datashape/blob/master/docs/source/types.rst#maps

