### PR TITLE
Incorrect results computing against interactive dict data

### DIFF
--- a/blaze/compute/core.py
+++ b/blaze/compute/core.py
@@ -139,8 +139,8 @@ def top_then_bottom_then_top_again_etc(expr, scope, **kwargs):
     top_to_bottom -- older version
     bottom_up -- older version still
     """
-    rl = kwargs.get('_recurse_level', 0)
-    kwargs['_recurse_level'] = rl
+    # rl = kwargs.get('_recurse_level', 0)
+    # kwargs['_recurse_level'] = rl
     # print('\t' * rl, ' -- ttbttae:', str(expr))
     # for k, v in scope.items():
     #     if rl > 2:
@@ -194,7 +194,7 @@ def top_then_bottom_then_top_again_etc(expr, scope, **kwargs):
                                   "expr: %s\n"
                                   "data: %s" % (type(expr3), expr3, scope4))
     else:
-        kwargs['_recurse_level'] += 1
+        # kwargs['_recurse_level'] += 1
         return top_then_bottom_then_top_again_etc(expr3, scope4, **kwargs)
 
 

--- a/blaze/compute/core.py
+++ b/blaze/compute/core.py
@@ -141,11 +141,11 @@ def top_then_bottom_then_top_again_etc(expr, scope, **kwargs):
     """
     rl = kwargs.get('_recurse_level', 0)
     kwargs['_recurse_level'] = rl
-    print('\t' * rl, ' -- ttbttae:', str(expr))
-    for k, v in scope.items():
-        if rl > 2:
-            v = list(v)
-        print('\t' * rl, '\t', k, '->', v)
+    # print('\t' * rl, ' -- ttbttae:', str(expr))
+    # for k, v in scope.items():
+    #     if rl > 2:
+    #         v = list(v)
+    #     print('\t' * rl, '\t', k, '->', v)
     # 0. Base case: expression is in dict, return associated data
     if expr in scope:
         return scope[expr]

--- a/blaze/compute/core.py
+++ b/blaze/compute/core.py
@@ -71,6 +71,7 @@ def compute_down(expr, **kwargs):
 
     inputs match up to leaves of the expression
     """
+
     return expr
 
 
@@ -138,6 +139,13 @@ def top_then_bottom_then_top_again_etc(expr, scope, **kwargs):
     top_to_bottom -- older version
     bottom_up -- older version still
     """
+    rl = kwargs.get('_recurse_level', 0)
+    kwargs['_recurse_level'] = rl
+    print('\t' * rl, ' -- ttbttae:', str(expr))
+    for k, v in scope.items():
+        if rl > 2:
+            v = list(v)
+        print('\t' * rl, '\t', k, '->', v)
     # 0. Base case: expression is in dict, return associated data
     if expr in scope:
         return scope[expr]
@@ -186,6 +194,7 @@ def top_then_bottom_then_top_again_etc(expr, scope, **kwargs):
                                   "expr: %s\n"
                                   "data: %s" % (type(expr3), expr3, scope4))
     else:
+        kwargs['_recurse_level'] += 1
         return top_then_bottom_then_top_again_etc(expr3, scope4, **kwargs)
 
 
@@ -383,17 +392,22 @@ def compute(expr, d, return_type=no_default, **kwargs):
     >>> list(compute(deadbeats, {t: data}))
     ['Bob', 'Charlie']
     """
+    # import ipdb; ipdb.set_trace()
     _reset_leaves()
     optimize_ = kwargs.get('optimize', optimize)
     pre_compute_ = kwargs.get('pre_compute', pre_compute)
     post_compute_ = kwargs.get('post_compute', post_compute)
     expr2, d2 = swap_resources_into_scope(expr, d)
     if pre_compute_:
-        d3 = dict(
-            (e, pre_compute_(e, dat, **kwargs))
-            for e, dat in d2.items()
-            if e in expr2
-        )
+        d3 = {}
+        for e, dat in d2.items():
+            if e in expr2:
+                d3[e] = pre_compute(e, dat, **kwargs)
+        # d3 = dict(
+        #     (e, pre_compute_(e, dat, **kwargs))
+        #     for e, dat in d2.items()
+        #     if e in expr2
+        # )
     else:
         d3 = d2
 

--- a/blaze/compute/python.py
+++ b/blaze/compute/python.py
@@ -373,8 +373,8 @@ def compute_up(expr, seq, predicate, **kwargs):
     # print('compute_up seq:', list(copy_seq))
     # print('compute_up preds:', list(copy_preds))
     preds = iter(predicate)
-    import cuid
-    filter_id = cuid.slug()
+    import uuid
+    filter_id = uuid.uuid4()
     def filter_(item):
         include_ = next(preds)
         print('filter:', filter_id, item, include_)

--- a/blaze/compute/python.py
+++ b/blaze/compute/python.py
@@ -377,7 +377,7 @@ def compute_up(expr, seq, predicate, **kwargs):
     filter_id = uuid.uuid4()
     def filter_(item):
         include_ = next(preds)
-        print('filter:', filter_id, item, include_)
+        # print('filter:', filter_id, item, include_)
         return include_
 
     return filter(filter_, seq)

--- a/blaze/compute/python.py
+++ b/blaze/compute/python.py
@@ -105,10 +105,18 @@ Sequence = (tuple, list, Iterator, type(dict().items()))
 
 @dispatch(Expr, Sequence)
 def pre_compute(expr, seq, scope=None, **kwargs):
+    # import ipdb; ipdb.set_trace()
+    # seq, copy_ = itertools.tee(seq)
+    # rl = kwargs.get('_recurse_level', 0) + 1
+    # print('\t' * rl, '>> pre_compute:')
+    # print('\t' * rl, '\t expr:', expr)
+    # print('\t' * rl, '\t seq:', seq)
+    # print('\t' * rl, '\t scope:', scope)
+    # print('\t' * rl, '\t kwargs:', kwargs)
     try:
         if isinstance(seq, Iterator):
             first = next(seq)
-            seq = concat([[first], seq])
+            seq = itertools.chain([first], seq)
         else:
             first = next(iter(seq))
     except StopIteration:
@@ -360,8 +368,19 @@ def compute_up(t, seq, **kwargs):
 
 @dispatch(Selection, Sequence, Sequence)
 def compute_up(expr, seq, predicate, **kwargs):
+    # seq, copy_seq = itertools.tee(seq)
+    # predicate, copy_preds = itertools.tee(predicate)
+    # print('compute_up seq:', list(copy_seq))
+    # print('compute_up preds:', list(copy_preds))
     preds = iter(predicate)
-    return filter(lambda _: next(preds), seq)
+    import cuid
+    filter_id = cuid.slug()
+    def filter_(item):
+        include_ = next(preds)
+        print('filter:', filter_id, item, include_)
+        return include_
+
+    return filter(filter_, seq)
 
 
 @dispatch(Reduction, Sequence)

--- a/blaze/compute/tests/test_python_compute.py
+++ b/blaze/compute/tests/test_python_compute.py
@@ -68,10 +68,57 @@ def test_eq():
 
 
 def test_selection():
-    assert list(compute(t[t['amount'] == 0], data)) == \
+    assert list(compute(t[t['amount'] == 0], data)) ==\
                 [x for x in data if x[1] == 0]
-    assert list(compute(t[t['amount'] > 150], data)) == \
+    assert list(compute(t[t['amount'] > 150], data)) ==\
                 [x for x in data if x[1] > 150]
+    # Also test with it in interactive mode, i.e. backed directly by data
+    # on the leaves. We are effectively doing the inverse of
+    # `swap_resources_into_scope` here.
+    # NOTE: It's possible this should go in `tests/test_interactive`
+    t2_data = blaze.data(data, dshape=t.dshape)
+    t2 = t._subs({t: t2_data})
+    assert list(compute(t2[t2['amount'] == 0])) ==\
+        [x for x in data if x[1] == 0]
+    assert list(compute(t2[t2['amount'] > 150])) ==\
+        [x for x in data if x[1] > 150]
+
+
+class PrintyList(list):
+    def __iter__(self):
+        import cuid
+        iterator_id = cuid.slug()
+        print('list:make_iter', iterator_id)
+        return self._generate_contents(iterator_id)
+
+    def _generate_contents(self, iid):
+        for x in list.__iter__(self):
+            print('  list:', iid, '__next__:', x)
+            yield x
+
+selection_data = PrintyList([{'id': 1, 'url': '/'},
+                  {'id': 2, 'url': '/foo'},
+                  {'id': 3, 'url': '/'},
+                  {'id': 4, 'url': '/foo'},
+                  {'id': 5, 'url': '/'},
+                  {'id': 6, 'url': '/foo'}])
+
+s1 = blaze.data(selection_data)
+
+def test_selection_interactive():
+    assert list(compute(s1[s1['url'] == '/'])) == \
+        [(s['id'], s['url']) for s in selection_data if s['url'] == '/']
+    # assert list(compute(s1[s1['url'] != '/'])) == \
+    #     [(s['id'], s['url']) for s in selection_data if s['url'] != '/']
+
+
+def test_selection_some_more():
+    d = symbol('d', s1.dshape)
+    d_data = [(x['id'], x['url']) for x in selection_data]
+    assert list(compute(d[d['url'] == '/'], d_data)) == \
+        [(s['id'], s['url']) for s in selection_data if s['url'] == '/']
+    assert list(compute(d[d['url'] != '/'], d_data)) == \
+        [(s['id'], s['url']) for s in selection_data if s['url'] != '/']
 
 
 def test_arithmetic():

--- a/blaze/compute/tests/test_python_compute.py
+++ b/blaze/compute/tests/test_python_compute.py
@@ -86,8 +86,8 @@ def test_selection():
 
 class PrintyList(list):
     def __iter__(self):
-        import cuid
-        iterator_id = cuid.slug()
+        import uuid
+        iterator_id = uuid.uuid4()
         print('list:make_iter', iterator_id)
         return self._generate_contents(iterator_id)
 

--- a/blaze/compute/tests/test_python_compute.py
+++ b/blaze/compute/tests/test_python_compute.py
@@ -84,24 +84,13 @@ def test_selection():
         [x for x in data if x[1] > 150]
 
 
-class PrintyList(list):
-    def __iter__(self):
-        import uuid
-        iterator_id = uuid.uuid4()
-        print('list:make_iter', iterator_id)
-        return self._generate_contents(iterator_id)
-
-    def _generate_contents(self, iid):
-        for x in list.__iter__(self):
-            print('  list:', iid, '__next__:', x)
-            yield x
-
-selection_data = PrintyList([{'id': 1, 'url': '/'},
+selection_data = [{'id': 1, 'url': '/'},
                   {'id': 2, 'url': '/foo'},
                   {'id': 3, 'url': '/'},
                   {'id': 4, 'url': '/foo'},
                   {'id': 5, 'url': '/'},
-                  {'id': 6, 'url': '/foo'}])
+                  {'id': 6, 'url': '/foo'},
+                  {'id': 7, 'url': '/'}]
 
 s1 = blaze.data(selection_data)
 

--- a/blaze/dispatch.py
+++ b/blaze/dispatch.py
@@ -9,4 +9,3 @@ __all__ = 'dispatch', 'namespace'
 
 
 dispatch = partial(dispatch, namespace=namespace)
-


### PR DESCRIPTION
This introduces a failing test for interactive computation on a list-of-dictionaries. No solution as yet but opening the PR should allow the Travis-CI tests to complete, and provide a place for discussion. The test is in `blaze/compute/tests/test_python_compute.py` and named `test_selection_interactive`.

The test can be run on its own with:

```
py.test blaze/compute/tests/test_python_compute.py::test_selection_interactive
```
