### PR TITLE
ENH: fix dayof(week|year) for sql and update dtypes for datetime exprs

### DIFF
--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -94,6 +94,7 @@ from ..expr import (
     StrSlice,
     var,
 )
+from ..expr.datetime import dayofweek
 from ..expr.strings import len as str_len
 from ..expr.broadcast import broadcast_collect
 from ..expr.math import isnan
@@ -1313,10 +1314,54 @@ def compute_up(expr, data, **kwargs):
 
 @dispatch(DateTime, ColumnElement)
 def compute_up(expr, data, **kwargs):
-    if expr.attr == 'date':
+    attr = expr.attr
+    if attr == 'date':
         return sa.func.date(data).label(expr._name)
+    elif attr == 'dayofyear':
+        attr = 'doy'
 
-    return sa.extract(expr.attr, data).label(expr._name)
+    return sa.extract(attr, data).cast(dshape_to_alchemy(expr.schema)).label(
+        expr._name,
+    )
+
+
+@dispatch(dayofweek, ColumnElement)
+def compute_up(expr, data, **kwargs):
+    # ``datetime.datetime.weekday()`` and ``pandas.Timestamp.dayofweek`` use
+    # monday=0 but sql uses sunday=0. We add 6 (7 - 1) to subtract 1 in Z7
+    # which will align on monday=0.
+    # We cannot use ``(extract(dow from data) - 1) % 7`` because in sql
+    # ``-1 % 7 = -1``, so instead we roll forward by 6 which is functionally
+    # equivalent.
+    # We also need to cast the result of the extract to a small integer because
+    # postgres returns a double precision for the result.
+
+    #     January 2014
+    # Su Mo Tu We Th Fr Sa
+    #           1  2  3  4
+    #  5  6  7  8  9 10 11
+    # 12 13 14 15 16 17 18
+    # 19 20 21 22 23 24 25
+    # 26 27 28 29 30 3
+
+    # 2014-01-05 is a Sunday
+    # bz=# select extract('dow' from '2014-01-05'::timestamp);
+    #  date_part
+    # -----------
+    #          0
+    # (1 row)
+    #
+    # In [1]: pd.Timestamp('2014-01-05').dayofweek
+    # Out[1]: 6
+    #
+    # bz=# select extract('dow' from '2014-01-05'::timestamp)::smallint + 6 % 7;
+    #  ?column?
+    # ----------
+    #         6
+    # (1 row)
+    return ((sa.extract('dow', data).cast(sa.SmallInteger) + 6) % 7).label(
+        expr._name,
+    )
 
 
 @dispatch(DateTimeTruncate, ColumnElement)

--- a/blaze/compute/tests/test_pandas_compute.py
+++ b/blaze/compute/tests/test_pandas_compute.py
@@ -836,18 +836,31 @@ def test_rowwise_by():
     tm.assert_frame_equal(result, expected)
 
 
-def test_datetime_access():
+@pytest.mark.parametrize(
+    'attr', (
+        'day',
+        'month',
+        'week',
+        'minute',
+        'second',
+        'dayofweek',
+        'weekday',
+        'dayofyear',
+        'quarter',
+    ),
+)
+def test_datetime_access(attr):
     df = DataFrame({'name': ['Alice', 'Bob', 'Joe'],
-                    'when': [datetime(2010, 1, 1, 1, 1, 1)] * 3,
+                    # 2002 is used because the dayofyear 1 is the same as
+                    # dayofweek 1
+                    'when': [datetime(2002, 1, 1, 1, 1, 1)] * 3,
                     'amount': [100, 200, 300],
                     'id': [1, 2, 3]})
 
     t = symbol('t', discover(df))
-
-    for attr in ['day', 'month', 'minute', 'second']:
-        expr = getattr(t.when, attr)
-        assert_series_equal(compute(expr, df),
-                            Series([1, 1, 1], name=expr._name))
+    expr = getattr(t.when.dt, attr)()
+    assert_series_equal(compute(expr, df),
+                        Series([1, 1, 1], name=expr._name))
 
 
 @pytest.mark.parametrize('attr, args, expected',

--- a/blaze/compute/tests/test_postgresql_compute.py
+++ b/blaze/compute/tests/test_postgresql_compute.py
@@ -35,6 +35,7 @@ from blaze import (
 )
 from blaze.interactive import iscorescalar
 from blaze.utils import example, normalize
+from blaze.compatibility import assert_series_equal
 
 
 names = ('tbl%d' % i for i in itertools.count())
@@ -849,3 +850,26 @@ def test_selection_selectable(sql):
                     return_type=pd.DataFrame) ==
             pd.DataFrame([['a', 1]],
                          columns=s.dshape.measure.names)).all().all()
+
+
+@pytest.mark.parametrize(
+    'attr', (
+        'day',
+        'month',
+        'week',
+        'minute',
+        'second',
+        'dayofweek',
+        'weekday',
+        'dayofyear',
+        'quarter',
+    ),
+)
+def test_datetime_access(attr, sql_with_dts):
+    s = symbol('s', discover(sql_with_dts))
+    expr = getattr(s.A.dt, attr)()
+    assert_series_equal(
+        compute(expr, sql_with_dts, return_type=pd.Series),
+        getattr(compute(s.A, sql_with_dts, return_type=pd.Series).dt, attr),
+        check_names=False,
+    )

--- a/blaze/compute/tests/test_sql_compute.py
+++ b/blaze/compute/tests/test_sql_compute.py
@@ -1682,10 +1682,10 @@ def test_date_grouper_repeats_not_one_point_oh():
 
     # FYI spark sql isn't able to parse this correctly
     expected = """SELECT
-        EXTRACT(year FROM t.ds) as ds_year,
+        CAST(EXTRACT(year FROM t.ds) AS INTEGER) as ds_year,
         AVG(t.amount) as avg_amt
     FROM t
-    GROUP BY EXTRACT(year FROM t.ds)
+    GROUP BY CAST(EXTRACT(year FROM t.ds) AS INTEGER)
     """
     assert normalize(result) == normalize(expected)
 

--- a/blaze/expr/datetime.py
+++ b/blaze/expr/datetime.py
@@ -131,14 +131,14 @@ def utcfromtimestamp(expr):
 
 
 class nanosecond(DateTime): _dtype = datashape.int64
-class week(DateTime): _dtype = datashape.int64
-class weekday(DateTime): _dtype = datashape.int64
+class week(DateTime): _dtype = datashape.int16
 class weekday_name(DateTime): _dtype = datashape.string
-class daysinmonth(DateTime): _dtype = datashape.int64
-class weekofyear(DateTime): _dtype = datashape.int64
-class dayofyear(DateTime): _dtype = datashape.int64
-class dayofweek(DateTime): _dtype = datashape.int64
-class quarter(DateTime): _dtype = datashape.int64
+class daysinmonth(DateTime): _dtype = datashape.int16
+class weekofyear(DateTime): _dtype = datashape.int16
+class dayofyear(DateTime): _dtype = datashape.int16
+class dayofweek(DateTime): _dtype = datashape.int16
+weekday = dayofweek  # alias
+class quarter(DateTime): _dtype = datashape.int16
 class is_month_start(DateTime): _dtype = datashape.bool_
 class is_month_end(DateTime): _dtype = datashape.bool_
 class is_quarter_start(DateTime): _dtype = datashape.bool_
@@ -312,7 +312,9 @@ class dt_ns(object):
     def nanosecond(self):
         return nanosecond(self.field)
     def weekday(self):
-        return weekday(self.field)
+        """Alias for dayofweek
+        """
+        return dayofweek(self.field)
     def weekday_name(self):
         return weekday_name(self.field)
     def daysinmonth(self):

--- a/docs/source/whatsnew/0.11.1.txt
+++ b/docs/source/whatsnew/0.11.1.txt
@@ -40,9 +40,12 @@ Bug Fixes
 
 * Fixed a testing regression introduced by the latest pymysql version
 (:issue:`1571`).
-
 * Fixed unicode conversion issues when using a Python 3 blaze server and a
   Python 2 client (:issue:`1572`), (:issue:`1566`).
+* Fixed ``dayofweek`` and ``dayofyear`` expressions for the SQL backend. The
+  ``dayofweek`` expression uses monday = 0 like :class:`datetime.datetime` and
+  :class:`pandas.Timestamp` instead of the SQL convention of sunday = 0.
+  (:issue:`1585`).
 
 Miscellaneous
 ~~~~~~~~~~~~~


### PR DESCRIPTION
We were using int64 where we could store the result in a much smaller type. We cannot go all the way down to i8 for these because sql small integer maps to an i16 so it is just easier to leave this here than to make i8 map to small integer also.

This mainly cleans up that `extract` uses the names `dow` and `doy` for `dayofweek` and `dayofyear`.

I also correct that sql dow uses sunday=0 but `datetime.datetime` and `pandas` use `monday=0`
