### PR TITLE
Support joins with foreign keys represented as `map[]` datashapes.

### DIFF
--- a/blaze/expr/collections.py
+++ b/blaze/expr/collections.py
@@ -538,7 +538,7 @@ class Join(Expr):
             self.rhs.dshape.measure.dict,
         )
         joined = (
-            (name, promote(dt, right_types[name], promote_option=False))
+            (name, promote(extract_key(dt), extract_key(right_types[name]), promote_option=False))
             for n, (name, dt) in enumerate(filter(
                 compose(op.contains(on_left), first),
                 self.lhs.dshape.measure.fields,
@@ -608,6 +608,10 @@ def types_of_fields(fields, expr):
         return expr.dshape.measure
 
 
+def extract_key(m):
+    return m.measure.key if isinstance(m.measure, datashape.coretypes.Map) else m
+
+
 @copydoc(Join)
 def join(lhs, rhs, on_left=None, on_right=None,
          how='inner', suffixes=('_left', '_right')):
@@ -627,6 +631,9 @@ def join(lhs, rhs, on_left=None, on_right=None,
         )
     left_types = listpack(types_of_fields(on_left, lhs))
     right_types = listpack(types_of_fields(on_right, rhs))
+    # Replace map[x, y] with x to resolve foreign keys.
+    left_types = list(map(extract_key, left_types))
+    right_types = list(map(extract_key, right_types))
     if len(left_types) != len(right_types):
         raise ValueError(
             'Length of on_left=%d not equal to length of on_right=%d' % (

--- a/blaze/tests/test_sql.py
+++ b/blaze/tests/test_sql.py
@@ -2,13 +2,14 @@ import pytest
 
 pytest.importorskip('sqlalchemy')
 
+from datashape import dshape
 from functools import partial
 
 from toolz import first
 from sqlalchemy.exc import OperationalError
 from odo import into, drop
 
-from blaze import data as bz_data
+from blaze import data as bz_data, join, symbol
 from blaze import create_index
 
 
@@ -97,3 +98,9 @@ def test_ignore_existing(sql, cols):
 
     # Shouldn't error
     create_call(ignore_existing=True)
+
+
+def test_join_foreign_key():
+    a = symbol('a', "var * {timestamp: string, pkid: map[int32, {pkid: int32, label: ?string}]}")
+    b = symbol('a', "var * {pkid: int32, label: ?string}")
+    assert join(a, b, 'pkid', 'pkid').dshape == dshape("var * {pkid: int32, timestamp: string, label: ?string}")


### PR DESCRIPTION
Fixes #1568.
