### PR TITLE
When converting `return_type` in `compute`, make use of known datashape

### DIFF
--- a/blaze/compute/core.py
+++ b/blaze/compute/core.py
@@ -424,7 +424,7 @@ def compute(expr, d, return_type=no_default, **kwargs):
         result = coerce_core(result, expr.dshape)
     # user specified type
     elif isinstance(return_type, type):
-        result = into(return_type, result)
+        result = into(return_type, result, dshape=expr.dshape)
     elif return_type != 'native':
         raise ValueError(
             "Invalid return_type passed to compute: {}".format(return_type),


### PR DESCRIPTION
Currently, `odo` is not able to make use of the right data-types for its return values because it does not have knowledge of the result expression's datashape -- this passes the shape into `odo.into` to ensure that's present. 

Actual code by @mcg1969, I'm just the courier ;-)