### PR TITLE
Variadic expressions

### DIFF
--- a/blaze/compute/core.py
+++ b/blaze/compute/core.py
@@ -6,11 +6,11 @@ import itertools
 import numbers
 import warnings
 
+from odo import odo
+import pandas as pd
 import toolz
 from toolz import first, unique, assoc
 from toolz.utils import no_default
-import pandas as pd
-from odo import odo
 
 from ..compatibility import basestring
 from ..expr import Expr, Field, Symbol, symbol, Join, Cast

--- a/blaze/compute/numpy.py
+++ b/blaze/compute/numpy.py
@@ -20,6 +20,7 @@ from ..utils import keywords
 
 from .core import base, compute
 from .pandas import array_coalesce
+from .varargs import register_varargs_arity
 from ..dispatch import dispatch
 from odo import into
 import pandas as pd
@@ -331,7 +332,7 @@ def compute_up(expr, x, **kwargs):
 
 @dispatch(Cast, np.ndarray)
 def compute_up(t, x, **kwargs):
-    # resolve ambiguity
+    # resolve ambiguity with [Expr, np.array]
     return x
 
 
@@ -342,6 +343,10 @@ def compute_up(t, x, **kwargs):
         return compute_up(t, into(DataFrame, x, dshape=ds), **kwargs)
     else:
         return compute_up(t, into(Series, x, dshape=ds), **kwargs)
+
+
+# resolve the ambiguous overload here with [Expr, np.ndarray]
+register_varargs_arity(1, type_=np.ndarray)
 
 
 @dispatch(nelements, np.ndarray)

--- a/blaze/compute/spark.py
+++ b/blaze/compute/spark.py
@@ -6,19 +6,38 @@ from toolz import compose, identity
 from datashape.predicates import isscalar
 
 from ..expr import (
-    Expr, ElemWise, SimpleSelection, Sort, Apply, Distinct, Join, By, Label,
-    Summary, by, ReLabel, Like, Reduction, Head
+    Apply,
+    By,
+    Distinct,
+    ElemWise,
+    Expr,
+    Head,
+    Join,
+    Label,
+    Like,
+    Merge,
+    ReLabel,
+    Reduction,
+    SimpleSelection,
+    Sort,
+    Summary,
+    by,
 )
 from .python import (
-    compute, rrowfunc, rowfunc, pair_assemble, reduce_by_funcs, binops
+    binops,
+    compute,
+    pair_assemble,
+    reduce_by_funcs,
+    rowfunc,
+    rrowfunc,
 )
 from ..expr.broadcast import broadcast_collect
 from ..expr.optimize import simple_selections
 from ..compatibility import builtins, unicode
 from ..expr import reductions
 from ..dispatch import dispatch
-
 from .core import compute_up
+from .varargs import VarArgs
 
 import py4j
 from pyspark import SparkContext
@@ -47,6 +66,12 @@ def optimize(expr, seq):
 def compute_up(t, rdd, **kwargs):
     func = rowfunc(t)
     return rdd.map(func)
+
+
+@dispatch(Merge, VarArgs[RDD])
+def compute_up(expr, args, **kwargs):
+    # TODO: How is this done in spark?
+    raise NotImplementedError()
 
 
 @dispatch(SimpleSelection, RDD)

--- a/blaze/compute/tests/test_optimize_compute.py
+++ b/blaze/compute/tests/test_optimize_compute.py
@@ -1,5 +1,6 @@
 from blaze.expr import Expr, symbol, Cast
 from blaze.compute import compute_up
+from blaze.compute.varargs import register_varargs_arity
 from blaze import compute
 
 
@@ -7,10 +8,12 @@ class Foo(object):
     def __init__(self, data):
         self.data = data
 
-
 @compute_up.register((Expr, Cast), Foo)
 def compute_up(expr, data, **kwargs):
     return data
+
+# We need to resolve this ambiguity for test_no_dispatch_ambiguities
+register_varargs_arity(1, Foo)
 
 
 def optimize(expr, data):

--- a/blaze/compute/tests/test_postgresql_compute.py
+++ b/blaze/compute/tests/test_postgresql_compute.py
@@ -555,7 +555,7 @@ def test_foreign_key_isin(fkey):
     assert normalize(str(result)) == normalize(expected)
 
 
-@pytest.mark.xfail(raises=AssertionError, reason='Not yet implemented')
+@pytest.mark.xfail(raises=ValueError, reason='Not yet implemented')
 def test_foreign_key_merge_expression(fkey):
     from blaze import merge
 
@@ -715,7 +715,7 @@ def test_sample(big_sql):
                                  slice(0, 1), slice(None, 3),
                                  slice(0, None), slice(2, None)])
 def test_str_slice(slc, sql_with_null):
-    name_series = pd.Series(['Alice', None, 'Drew', 'Bob', 'Drew', 'first', None],       
+    name_series = pd.Series(['Alice', None, 'Drew', 'Bob', 'Drew', 'first', None],
                             name='substring_1')
     t = symbol('t', discover(sql_with_null))
     result = compute(t.name.str[slc], sql_with_null, return_type=pd.Series).fillna('zzz')
@@ -775,7 +775,7 @@ def test_str_cat_bcast(sql_with_null):
     assert all(expected[~expected.isnull()] == result[~result.isnull()])
     assert all(expected[expected.isnull()].index == result[result.isnull()].index)
 
-    
+
 
 def test_str_cat_where_clause(sql_with_null):
     """

--- a/blaze/compute/tests/test_spark.py
+++ b/blaze/compute/tests/test_spark.py
@@ -229,6 +229,7 @@ def test_multi_level_rowfunc_works(rdd):
     assert compute(expr, rdd).collect() == [x[1] + 1 for x in data]
 
 
+@pytest.mark.xfail(NotImplementedError, reason='how is this done in spark?')
 def test_merge(rdd):
     col = (t['amount'] * 2).label('new')
     expr = merge(t['name'], col)

--- a/blaze/compute/tests/test_sql_compute.py
+++ b/blaze/compute/tests/test_sql_compute.py
@@ -1440,10 +1440,10 @@ def test_transform_where():
         abs(accounts.amount) as abs_amt,
         sin(accounts.id) as sine
     FROM accounts
-    WHERE accounts.id = :id_1
+    WHERE accounts.id = 1
     """
 
-    assert normalize(str(result)) == normalize(expected)
+    assert normalize(result) == normalize(expected)
 
 
 def test_merge():
@@ -1950,12 +1950,12 @@ def test_label_projection():
     result2 = compute(expr.one_two[expr.new_amount > 1], s, return_type='native')
 
     expected = """SELECT
-        accounts.amount * :amount_1 as one_two
+        accounts.amount * 2 as one_two
     FROM accounts
-    WHERE accounts.name = :name_1 and accounts.amount + :amount_2 > :param_1
+    WHERE accounts.name = 'Alice' and accounts.amount + 1 > 1
     """
-    assert normalize(str(result)) == normalize(expected)
-    assert normalize(str(result2)) == normalize(expected)
+    assert normalize(result) == normalize(expected)
+    assert normalize(result2) == normalize(expected)
 
 
 def test_baseball_nested_by():

--- a/blaze/compute/varargs.py
+++ b/blaze/compute/varargs.py
@@ -1,0 +1,136 @@
+from abc import ABCMeta
+
+from datashape.py2help import with_metaclass
+from toolz import unique, memoize
+
+from .core import compute_up
+
+
+def flatten(ts):
+    """Flatten a (potentially nested) sequence of tuples into just scalars.
+    """
+    for t in ts:
+        if isinstance(t, tuple):
+            for flat in flatten(t):
+                yield flat
+        else:
+            yield t
+
+
+class _VarArgsMeta(type):
+    """Metaclass for ``VarArgs`` which allows us to create type-checked
+    subclasses using ``__getitem__`` syntax.
+    """
+    @staticmethod
+    @memoize
+    def __getitem__(types):
+        if not isinstance(types, tuple):
+            # only a single type is given, promote to a sequence
+            types = types,
+        else:
+            # flatten the types out and remove any duplicates
+            types = tuple(unique(flatten(types)))
+
+        class TypedVarArgs(with_metaclass(_TypedVarArgsMeta, VarArgs)):
+            _types = types
+
+        name = 'VarArgs[%s]' % ', '.join(
+            getattr(type_, '__name__', str(type_)) for type_ in types
+        )
+        TypedVarArgs.__name__ = TypedVarArgs.__qualname__ = name
+        return TypedVarArgs
+
+
+class _TypedVarArgsMeta(ABCMeta, _VarArgsMeta):
+    """Metaclass for type-checked subclasses of ``VarArgs`` which implement
+    ``__subclasscheck__`` for type dispatch.
+    """
+    def __subclasscheck__(self, other):
+        self_types = self._types
+        return (
+            isinstance(other, type(self)) and
+            all(issubclass(type_, self_types) for type_ in other._types)
+        )
+
+
+class VarArgs(with_metaclass(_VarArgsMeta, tuple)):
+    """An immutable, typed variadic sequence.
+
+    Parameters
+    ----------
+    args : iterable[any]
+        The values to create a ``VarArgs`` from.
+
+    Notes
+    -----
+    To create a type-checked subclass, use: ``VarArgs[Type1, Type2, ...]``.
+    """
+    def __new__(cls, args):
+        args = tuple(args)
+        if cls is VarArgs:
+            # if ``VarArgs`` is created directly infer the type from the args
+            return cls[tuple(map(type, args))](args)
+
+        # this is the __new__ of the subclass, typecheck at construction time:
+        for n, arg in enumerate(args):
+            if not isinstance(arg, cls._types):
+                raise TypeError(
+                    'invalid type %s at index %d, must be one of %s' % (
+                        type(arg),
+                        n,
+                        cls._types,
+                    ),
+                )
+        return super(VarArgs, cls).__new__(cls, args)
+
+    def __repr__(self):
+        return '%s([%s])' % (
+            type(self).__name__,
+            super(VarArgs, self).__repr__()[1:-1],  # cut off the parens
+        )
+
+
+def _varargs_materialize(expr, *args, **kwargs):
+    """compute_up dispatch for VarArgs. We will dynamically register this
+    with multipledispatch based on the length of the varargs.
+    """
+    return VarArgs(args)
+
+
+def register_varargs_arity(arity, type_=object):
+    """Register a compute_up handler for a varargs of length ``arity``
+
+    Parameters
+    ----------
+    arity : int
+        The arity of the varargs dispatcher to register.
+    type_ : type, optional
+        The type to register the dispatch with. This defaults to ``object``.
+    """
+    cache = register_varargs_arity._cache.setdefault(type_, set())
+    if arity not in cache:
+        # we cache these because it can take almost 2 seconds to add a function
+        # to the compute_up dispatcher. If we have already registered
+        # a handler for the given arity and type then just return since this
+        # is a nop.
+
+        # lazy import to prevent cycles
+        from blaze.expr.expressions import VarArgsExpr
+
+        # use a cache here so that we don't need to reorder the compute_up
+        # dispatcher every time we create a VarArgsExpr.
+        compute_up.register(*(VarArgsExpr,) + (type_,) * arity)(
+            _varargs_materialize,
+        )
+        cache.add(arity)
+register_varargs_arity._cache = {}
+
+
+# Pre-register arities [0, 6] while we are halting multiple dispatch ordering as
+# a performance improvement.
+# NOTE: this number was picked because it seemed like a good balance of slowing
+# down later dispatches with speeding up common cases. We could tune this
+# better in the future.
+for n in range(7):
+    register_varargs_arity(n)
+del n

--- a/blaze/expr/arithmetic.py
+++ b/blaze/expr/arithmetic.py
@@ -61,7 +61,7 @@ Not
 
 class BinOp(ElemWise):
     _arguments = 'lhs', 'rhs'
-    __inputs__ = 'lhs', 'rhs'
+    _input_attributes = 'lhs', 'rhs'
 
     def __str__(self):
         lhs = parenthesize(eval_str(self.lhs))

--- a/blaze/expr/arrays.py
+++ b/blaze/expr/arrays.py
@@ -71,7 +71,7 @@ class TensorDot(Expr):
     tensordot(x, y, axes=[0, 0])
     """
     _arguments = 'lhs', 'rhs', '_left_axes', '_right_axes'
-    __inputs__ = 'lhs', 'rhs'
+    _input_attributes = 'lhs', 'rhs'
 
     def _dshape(self):
         # Compute shape

--- a/blaze/expr/collections.py
+++ b/blaze/expr/collections.py
@@ -484,7 +484,7 @@ class Join(Expr):
     blaze.expr.collections.Merge
     """
     _arguments = 'lhs', 'rhs', '_on_left', '_on_right', 'how', 'suffixes'
-    __inputs__ = 'lhs', 'rhs'
+    _input_attributes = 'lhs', 'rhs'
 
     @property
     def on_left(self):
@@ -700,7 +700,7 @@ class Concat(Expr):
     blaze.expr.collections.Merge
     """
     _arguments = 'lhs', 'rhs', 'axis'
-    __inputs__ = 'lhs', 'rhs'
+    _input_attributes = 'lhs', 'rhs'
 
     def _dshape(self):
         axis = self.axis

--- a/blaze/expr/collections.py
+++ b/blaze/expr/collections.py
@@ -6,42 +6,75 @@ from functools import partial
 from itertools import chain
 
 import datashape
-from datashape import (DataShape, Option, Record, Unit, dshape, var, Fixed,
-                       Var, promote, object_)
+from datashape import (
+    DataShape,
+    Fixed,
+    Option,
+    Record,
+    Unit,
+    Var,
+    dshape,
+    object_,
+    promote,
+    var,
+)
 from datashape.predicates import isscalar, iscollection, isrecord
-from toolz import (isdistinct, frequencies, concat as tconcat, unique, get,
-                   first, compose, keymap)
+from toolz import (
+    compose,
+    concat as tconcat,
+    concatv,
+    first,
+    frequencies,
+    get,
+    isdistinct,
+    keymap,
+)
 import toolz.curried.operator as op
 from odo.utils import copydoc
 
 from .core import common_subexpression
-from .expressions import Expr, ElemWise, label, Field
-from .expressions import dshape_method_list
+from .expressions import (
+    attribute,
+    _setattr,
+    ElemWise,
+    Expr,
+    Field,
+    Selection,
+    dshape_method_list,
+    label,
+    ndim,
+    shape,
+    varargsexpr,
+)
+from .utils import maxshape
 from ..compatibility import zip_longest, _strtypes
+from ..interactive import data
 from ..utils import listpack
 
 
-__all__ = ['Concat',
-           'concat',
-           'Distinct',
-           'distinct',
-           'Head',
-           'head',
-           'IsIn',
-           'isin',
-           'Join',
-           'join',
-           'Merge',
-           'merge',
-           'Sample',
-           'sample',
-           'Shift',
-           'shift',
-           'Sort',
-           'sort',
-           'Tail',
-           'tail',
-           'transform']
+__all__ = [
+    'Concat',
+    'concat',
+    'Distinct',
+    'distinct',
+    'Head',
+    'head',
+    'IsIn',
+    'isin',
+    'Join',
+    'join',
+    'Merge',
+    'merge',
+    'Sample',
+    'sample',
+    'Shift',
+    'shift',
+    'Sort',
+    'sort',
+    'Tail',
+    'tail',
+    'transform',
+]
 
 
 class Sort(Expr):
@@ -182,7 +215,7 @@ class Distinct(Expr):
     _arguments = '_child', 'on'
 
     def _dshape(self):
-        return datashape.var * self._child.dshape.measure
+        return var * self._child.dshape.measure
 
     @property
     def fields(self):
@@ -323,21 +356,6 @@ def sample(child, n=None, frac=None):
     return Sample(child, n, frac)
 
 
-def transform(t, replace=True, **kwargs):
-    """ Add named columns to table
-
-    >>> from blaze import symbol
-    >>> t = symbol('t', 'var * {x: int, y: int}')
-    >>> transform(t, z=t.x + t.y).fields
-    ['x', 'y', 'z']
-    """
-    if replace and set(t.fields).intersection(set(kwargs)):
-        t = t[[c for c in t.fields if c not in kwargs]]
-
-    args = [t] + [v.label(k) for k, v in sorted(kwargs.items(), key=first)]
-    return merge(*args)
-
-
 def schema_concat(exprs):
     """ Concatenate schemas together.  Supporting both Records and Units
 
@@ -357,8 +375,15 @@ def schema_concat(exprs):
 
 
 class Merge(ElemWise):
-
     """ Merge many fields together
+
+    Parameters
+    ----------
+    *labeled_exprs : iterable[Expr]
+        The positional expressions to merge. These will use the expression's
+        _name as the key in the resulting table.
+    **named_exprs : dict[str, Expr]
+        The named expressions to label and merge into the table.
 
     Examples
     --------
@@ -367,57 +392,103 @@ class Merge(ElemWise):
     >>> merge(accounts.name, z=accounts.x + accounts.y).fields
     ['name', 'z']
 
+    Notes
+    -----
     To control the ordering of the fields, use ``label``:
 
     >>> merge(label(accounts.name, 'NAME'), label(accounts.x, 'X')).dshape
     dshape("var * {NAME: string, X: int32}")
     >>> merge(label(accounts.x, 'X'), label(accounts.name, 'NAME')).dshape
     dshape("var * {X: int32, NAME: string}")
-    """
-    _arguments = '_child', 'children'
 
-    def _schema(self):
-        return schema_concat(self.children)
+    See Also
+    --------
+    :class:`~blaze.expr.expressions.label`
+    """
+    _arguments = 'args', '_varargsexpr', '_shape'
+    _input_attributes = '_varargsexpr',
+
+    def _dshape(self):
+        return DataShape(*self._shape + (schema_concat(self.args),))
 
     @property
     def fields(self):
-        return list(tconcat(child.fields for child in self.children))
-
-    def _subterms(self):
-        yield self
-        for i in self.children:
-            for node in i._subterms():
-                yield node
+        return list(tconcat(arg.fields for arg in self.args))
 
     def _get_field(self, key):
-        for child in self.children:
-            if key in child.fields:
-                if isscalar(child.dshape.measure):
-                    return child
+        for arg in self.args:
+            if key in arg.fields:
+                if isscalar(arg.dshape.measure):
+                    return arg
                 else:
-                    return child[key]
+                    return arg[key]
 
     def _project(self, key):
         if not isinstance(key, (tuple, list)):
             raise TypeError("Expected tuple or list, got %s" % key)
-        return merge(*[self[c] for c in key])
+        return merge(*(self[c] for c in key))
 
-    def _leaves(self):
-        return list(unique(tconcat(i._leaves() for i in self.children)))
+    def _select(self, predicate):
+        subexpr = common_subexpression(predicate, *self.args)
+        return self._subs({subexpr: Selection(subexpr, predicate)})
+
+    @attribute
+    def _child(self):
+        return _setattr(
+            self,
+            '_common_subexpr',
+            common_subexpression(*self.args),
+        )
+
+
+def _wrap(ob, name):
+    """Wrap an object in an interactive expression if it is not already
+    an object, otherwise return it unchanged.
+
+    Parameters
+    ----------
+    ob : any
+        The object to potentially wrap.
+    name : str
+        The name of the interactive expression if created.
+
+    Returns
+    -------
+    maybe_wrapped : Expr
+        A blaze expression.
+    """
+    return data(ob, name=name) if not isinstance(ob, Expr) else ob
 
 
 @copydoc(Merge)
 def merge(*exprs, **kwargs):
     if len(exprs) + len(kwargs) == 1:
+        # we only have one object so don't need to construct a merge
         if exprs:
+            # we only have a positional argumnent, return it unchanged
             return exprs[0]
         if kwargs:
+            # we only have a single keyword argument, label it and return it
             [(k, v)] = kwargs.items()
             return v.label(k)
-    # Get common sub expression
-    exprs += tuple(label(v, k) for k, v in sorted(kwargs.items(), key=first))
-    child = common_subexpression(*exprs)
-    result = Merge(child, exprs)
+
+    # label all the kwargs and sort in key order
+    exprs = tuple(concatv(
+        (_wrap(expr, '_%s' % n) for n, expr in enumerate(exprs)),
+        (
+            label(_wrap(v, k), k)
+            for k, v in sorted(kwargs.items(), key=first)
+        ),
+    ))
+
+    if all(ndim(expr) == 0 for expr in exprs):
+        raise TypeError('cannot merge all scalar expressions')
+
+    result = Merge(
+        exprs,
+        varargsexpr(exprs),
+        maxshape(map(shape, exprs)),
+    )
 
     if not isdistinct(result.fields):
         raise ValueError(
@@ -427,6 +498,44 @@ def merge(*exprs, **kwargs):
         )
 
     return result
+
+
+def transform(expr, replace=True, **kwargs):
+    """Add named columns to table
+
+    Parameters
+    ----------
+    expr : Expr
+        A tabular expression.
+    replace : bool, optional
+        Should new columns be allowed to replace old columns?
+    **kwargs
+        The new columns to add to the table
+
+    Returns
+    -------
+    merged : Merge
+        A new tabular expression with the new columns merged into the table.
+
+    Examples
+    --------
+    >>> from blaze import symbol
+    >>> t = symbol('t', 'var * {x: int, y: int}')
+    >>> transform(t, z=t.x + t.y).fields
+    ['x', 'y', 'z']
+
+    See Also
+    --------
+    :class:`~blaze.expr.collections.merge`
+    """
+    if replace and set(expr.fields).intersection(set(kwargs)):
+        expr = expr[[c for c in expr.fields if c not in kwargs]]
+
+    args = [expr] + [
+        _wrap(v, k).label(k) for k, v in sorted(kwargs.items(), key=first)
+    ]
+    return merge(*args)
+
 
 
 def unpack(l):

--- a/blaze/expr/core.py
+++ b/blaze/expr/core.py
@@ -130,7 +130,7 @@ class Node(object):
     blaze.expr.expressions.Expr
     """
     _arguments = '_child',
-    __inputs__ = '_child',
+    _input_attributes = '_child',
     __expr_instance_cache = WeakValueDictionary()
 
     def __new__(cls, *args, **kwargs):
@@ -164,7 +164,7 @@ class Node(object):
 
     @property
     def _inputs(self):
-        return tuple(getattr(self, i) for i in self.__inputs__)
+        return tuple(getattr(self, i) for i in self._input_attributes)
 
     def _leaves(self):
         """ Leaves of an expression tree

--- a/blaze/expr/core.py
+++ b/blaze/expr/core.py
@@ -23,7 +23,7 @@ __all__ = ['Node', 'path', 'common_subexpression', 'eval_str']
 base = (numbers.Number,) + _strtypes + (datetime.datetime, datetime.timedelta)
 
 
-def _resolve_args(cls, *args, **kwargs):
+def resolve_args(cls, *args, **kwargs):
     """Resolve the arguments from a node class into an ordereddict.
     All arguments are assumed to have a default of None.
 
@@ -49,23 +49,23 @@ def _resolve_args(cls, *args, **kwargs):
     ...
 
     good cases
-    >>> _resolve_args(MyNode, 1, 2, 3)
+    >>> resolve_args(MyNode, 1, 2, 3)
     OrderedDict([('a', 1), ('b', 2), ('c', 3)])
-    >>> _resolve_args(MyNode, 1, 2, c=3)
+    >>> resolve_args(MyNode, 1, 2, c=3)
     OrderedDict([('a', 1), ('b', 2), ('c', 3)])
-    >>> _resolve_args(MyNode, a=1, b=2, c=3)
+    >>> resolve_args(MyNode, a=1, b=2, c=3)
     OrderedDict([('a', 1), ('b', 2), ('c', 3)])
 
     error cases
-    >>> _resolve_args(MyNode, 1, 2, 3, a=4)
+    >>> resolve_args(MyNode, 1, 2, 3, a=4)
     Traceback (most recent call last):
        ...
     TypeError: MyNode got multiple values for argument 'a'
-    >>> _resolve_args(MyNode, 1, 2, 3, 4)
+    >>> resolve_args(MyNode, 1, 2, 3, 4)
     Traceback (most recent call last):
        ...
     TypeError: MyNode takes 3 positional arguments but 4 were given
-    >>> _resolve_args(MyNode, 1, 2, 3, d=4)
+    >>> resolve_args(MyNode, 1, 2, 3, d=4)
     Traceback (most recent call last):
        ...
     TypeError: MyNode got unknown keywords: d
@@ -82,8 +82,10 @@ def _resolve_args(cls, *args, **kwargs):
 
     if len(args) > len(attrs):
         raise TypeError(
-            '%s takes 3 positional arguments but %d were given' % (
+            '%s takes %d positional argument%s but %d were given' % (
                 cls.__name__,
+                len(attrs),
+                's' if len(attrs) > 1 else '',
                 len(args),
             ),
         )
@@ -145,7 +147,7 @@ class Node(object):
             return self
 
     def _init(self, *args, **kwargs):
-        for name, arg in _resolve_args(type(self), *args, **kwargs).items():
+        for name, arg in resolve_args(type(self), *args, **kwargs).items():
             _setattr(self, name, arg)
 
         _setattr(self, '_hash', None)
@@ -160,7 +162,7 @@ class Node(object):
 
     @classmethod
     def _static_identity(cls, *args, **kwargs):
-        return (cls,) + tuple(_resolve_args(cls, *args, **kwargs).values())
+        return (cls,) + tuple(resolve_args(cls, *args, **kwargs).values())
 
     @property
     def _inputs(self):
@@ -217,7 +219,7 @@ class Node(object):
         yield self
         traversals = (
             arg._traverse() if isinstance(arg, Node) else [arg]
-            for arg in self._args
+            for arg in self._inputs
         )
         for item in concat(traversals):
             yield item
@@ -234,8 +236,9 @@ class Node(object):
         return subs(self, d)
 
     def _resources(self):
-        return toolz.merge([arg._resources() for arg in self._args
-                            if isinstance(arg, Node)])
+        return toolz.merge(
+            arg._resources() for arg in self._inputs if isinstance(arg, Node)
+        )
 
     def _subterms(self):
         return subterms(self)
@@ -327,7 +330,7 @@ class Node(object):
         return self._and(other)
 
     def __rand__(self, other):
-        return self._rand(other)
+       return self._rand(other)
 
     def __neg__(self):
         return self._neg()

--- a/blaze/expr/expressions.py
+++ b/blaze/expr/expressions.py
@@ -10,7 +10,6 @@ from datashape import (
     DataShape,
     Record,
     Var,
-    Mono,
     Fixed,
     promote,
     Option,
@@ -20,15 +19,22 @@ from datashape.predicates import isscalar, iscollection, isboolean, isrecord
 import numpy as np
 from odo.utils import copydoc
 import toolz
-from toolz import concat, memoize, partial, first
+from toolz import concat, memoize, partial, first, unique, merge
 from toolz.curried import map, filter
 
 from ..compatibility import _strtypes, builtins, boundmethod, PY2
-from .core import Node, subs, common_subexpression, path, _setattr
+from .core import (
+    Node,
+    _setattr,
+    common_subexpression,
+    path,
+    resolve_args,
+    subs,
+)
 from .method_dispatch import select_functions
 from ..dispatch import dispatch
 from .utils import hashable_index, replace_slices, maxshape
-from ..utils import attribute
+from ..utils import attribute, as_attribute
 
 
 __all__ = [
@@ -129,7 +135,7 @@ class Expr(Node):
         if isinstance(key, _strtypes) and key in self.fields:
             return self._get_field(key)
         elif isinstance(key, Expr) and iscollection(key.dshape):
-            return selection(self, key)
+            return self._select(key)
         elif (isinstance(key, list) and
               builtins.all(isinstance(k, _strtypes) for k in key)):
             if set(key).issubset(self.fields):
@@ -147,9 +153,6 @@ class Expr(Node):
 
     def map(self, func, schema=None, name=None):
         return Map(self, func, schema, name)
-
-    def _project(self, key):
-        return projection(self, key)
 
     @attribute
     def schema(self):
@@ -221,7 +224,7 @@ class Expr(Node):
             fields = dict(zip(map(valid_identifier, self.fields), self.fields))
 
             measure = self.dshape.measure
-            if isinstance(measure, datashape.Map): # Foreign key
+            if isinstance(measure, datashape.Map):  # Foreign key
                 measure = measure.key
 
             # prefer the method if there's a field with the same name
@@ -256,7 +259,8 @@ class Expr(Node):
                                                        measure)):
             child_measure = self._child.dshape.measure
             if isscalar(getattr(child_measure, 'key', child_measure)):
-                return self._child._name
+                # memoize the result
+                return _setattr(self, '_name', self._child._name)
 
     def __enter__(self):
         """ Enter context """
@@ -273,6 +277,17 @@ class Expr(Node):
             except AttributeError:
                 pass
         return True
+
+    # Add some placeholders to help with refactoring. If we forget to attach
+    # these methods later we will get better errors.
+    # To find the real definition, look for usage of ``@as_attribute``
+    for method in ('_project', '_select', 'cast'):
+        @attribute
+        def _(self):
+            raise AssertionError('method added after class definition')
+        locals()[method] = _
+        del _
+        del method
 
 
 def sanitized_dshape(dshape, width=50):
@@ -417,6 +432,7 @@ class Projection(ElemWise):
                                                                self.fields))
 
 
+@as_attribute(Expr, '_project')
 @copydoc(Projection)
 def projection(expr, names):
     if not names:
@@ -522,12 +538,13 @@ class SimpleSelection(Selection):
     _input_attributes = '_child',
 
 
+@as_attribute(Expr, '_select')
 @copydoc(Selection)
 def selection(table, predicate):
     subexpr = common_subexpression(table, predicate)
 
     if not builtins.all(
-            isinstance(node, (ElemWise, Symbol)) or
+            isinstance(node, (VarArgsExpr, ElemWise, Symbol)) or
             node.isidentical(subexpr)
             for node in concat([path(predicate, subexpr),
                                 path(table, subexpr)])):
@@ -820,12 +837,10 @@ class Cast(Expr):
         return 'cast(%s, to=%r)' % (self._child, str(self.to))
 
 
+@as_attribute(Expr)
 @copydoc(Cast)
 def cast(expr, to):
     return Cast(expr, dshape(to) if isinstance(to, _strtypes) else to)
-
-
-Expr.cast = cast  # method of all exprs
 
 
 def binop_name(expr):
@@ -967,3 +982,33 @@ method_properties.update([shape, ndim])
 @dispatch(Expr)
 def discover(expr):
     return expr.dshape
+
+
+class VarArgsExpr(Expr):
+    """An expression used for collecting variadic arguments into a single, typed
+    container.
+
+    Parameters
+    ----------
+    _inputs : tuple[any]
+        The arguments that this expression will compute.
+    """
+    _arguments = '_inputs',
+
+    @attribute
+    def _inputs(self):
+        raise NotImplementedError('overridden in _init')
+
+    def _dshape(self):
+        return DataShape(datashape.void)
+
+
+def varargsexpr(args):
+    """Create a varargs expr which will be materialzed as a ``VarArgs``
+    """
+    # lazy import to break cycle
+    from blaze.compute.varargs import register_varargs_arity
+    args = tuple(args)
+    register_varargs_arity(len(args))
+
+    return VarArgsExpr(args)

--- a/blaze/expr/expressions.py
+++ b/blaze/expr/expressions.py
@@ -295,7 +295,7 @@ class Symbol(Expr):
     dshape("5 * 3 * {x: int32, y: int32}")
     """
     _arguments = '_name', 'dshape', '_token'
-    __inputs__ = ()
+    _input_attributes = ()
 
     def __repr__(self):
         fmt = "<`{}` symbol; dshape='{}'>"
@@ -500,7 +500,7 @@ class Selection(Expr):
     >>> deadbeats = accounts[accounts.amount < 0]
     """
     _arguments = '_child', 'predicate'
-    __inputs__ = '_child', 'predicate'
+    _input_attributes = '_child', 'predicate'
 
     @property
     def _name(self):
@@ -519,7 +519,7 @@ class SimpleSelection(Selection):
     """Internal selection class that does not treat the predicate as an input.
     """
     _arguments = Selection._arguments
-    __inputs__ = '_child',
+    _input_attributes = '_child',
 
 
 @copydoc(Selection)
@@ -868,7 +868,7 @@ class Coalesce(Expr):
     True
     """
     _arguments = 'lhs', 'rhs', 'dshape'
-    __inputs__ = 'lhs', 'rhs'
+    _input_attributes = 'lhs', 'rhs'
 
     def __str__(self):
         return 'coalesce(%s, %s)' % (self.lhs, self.rhs)

--- a/blaze/expr/strings.py
+++ b/blaze/expr/strings.py
@@ -250,7 +250,7 @@ class StrCat(ElemWise):
 
     """
     _arguments = 'lhs', 'rhs', 'sep'
-    __inputs__ = 'lhs', 'rhs'
+    _input_attributes = 'lhs', 'rhs'
 
     def _dshape(self):
         '''

--- a/blaze/expr/tests/test_expr.py
+++ b/blaze/expr/tests/test_expr.py
@@ -229,8 +229,8 @@ def test_coalesce():
     expr = coalesce(a_expr, b_expr)
     assert expr.isidentical(a_expr)
 
-    c = symbol('c', '{a: int32, b: int32}')
-    d = symbol('d', '{a: int32, b: int32}')
+    c = symbol('c', 'var * {a: int32, b: int32}')
+    d = symbol('d', 'var * {a: int32, b: int32}')
     expr = coalesce(c, d)
     assert expr.isidentical(c)
 

--- a/blaze/utils.py
+++ b/blaze/utils.py
@@ -17,6 +17,7 @@ from odo.utils import tmpfile, filetext, filetexts, raises, keywords, ignoring
 import pandas as pd
 import psutil
 import sqlalchemy as sa
+from toolz.curried import do
 
 # Imports that replace older utils.
 from .compatibility import map, zip
@@ -266,3 +267,23 @@ def parameter_space(*args):
     return tuple(product(*(
         arg if isinstance(arg, tuple) else (arg,) for arg in args
     )))
+
+
+def as_attribute(ob, name=None):
+    """Decorator to define an object as an attribute of another object.
+
+    Parameters
+    ----------
+    ob : any
+       The object to attach this to.
+    name : str, optional
+       The name of the attribute. By default this is the decorated value's
+       ``__name__``.
+
+    Returns
+    -------
+    dec : callable[any, any]
+        Decorator that registers an object as an attribute of another object and
+        returns it unchanged.
+    """
+    return do(lambda f: setattr(ob, f.__name__ if name is None else name, f))

--- a/docs/source/whatsnew/0.12.0.txt
+++ b/docs/source/whatsnew/0.12.0.txt
@@ -11,7 +11,9 @@ None
 Improved Expressions
 ~~~~~~~~~~~~~~~~~~~~
 
-None
+* Adds support for variadic expressions of known
+  types. :func:`~blaze.expr.expressions.merge` is now implemented as a variadic
+  expression (:issue:`1611`).
 
 New Backends
 ~~~~~~~~~~~~


### PR DESCRIPTION
Adds a new VarArgsExpr/VarArgs pair of objects for representing
sequences of known types but unknown length in the expression tree. This
allows us to use multipledispatch to define compute handlers for
expressions that conceptually accept a sequence like `Merge`.

This also implements `Merge` as a variadic expression.

Future work will be porting `Concat`.