### PR TITLE
TST: add appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ build_script:
   - SET PATH=C:\mongodb\bin;%PATH%
   - ps: 'mongo admin --eval "db.runCommand({setParameter: 1, textSearchEnabled: true});"'
 
-  #  MySql
+  # MySql
   # odo and mysql don't play nicely on win32
   # - SET PATH=C:\Program Files\MySql\MySQL Server 5.7\bin\;%PATH%
   # - mysql -u root -p"Password12!" -e "CREATE DATABASE IF NOT EXISTS test;"
@@ -56,8 +56,6 @@ build_script:
   # blaze required deps
   - pip install git+https://github.com/blaze/datashape
   - pip install git+https://github.com/blaze/odo
-
-  - python setup.py develop
 
 test_script:
   - conda list

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,64 @@
+skip_tags: true
+clone_depth: 50
+
+os: Visual Studio 2015
+
+environment:
+  matrix:
+    # - PY_MAJOR_VER: 2
+    #   PYTHON_ARCH: "x86_64"
+    - PY_MAJOR_VER: 3
+      PYTHON_ARCH: "x86_64"
+
+platform:
+    - x64
+
+services:
+  # - mssql2014 # No tests for mssql written yet
+  # - mysql # odo and mysql don't play well on win32
+  - postgresql93
+  - mongodb
+
+build_script:
+  - ps: Start-FileDownload "https://repo.continuum.io/miniconda/Miniconda$env:PY_MAJOR_VER-latest-Windows-$env:PYTHON_ARCH.exe" C:\Miniconda.exe; echo "Finished downloading miniconda"
+  - cmd: C:\Miniconda.exe /S /D=C:\Py
+  - SET PATH=C:\Py;C:\Py\Scripts;C:\Py\Library\bin;%PATH%
+  - conda config --set always_yes yes
+  - conda update conda --quiet
+  - conda create -n blaze python=3.5 numpy=1.11.2 numba=0.29.0 h5py=2.6.0
+  - activate blaze
+  - conda update setuptools pip
+
+  # sqlite
+  - ps: Start-FileDownload "https://sqlite.org/2016/sqlite-tools-win32-x86-3150200.zip" C:\sqlite.zip; echo "Finished downloading sqlite3"
+  - 7z e C:\sqlite.zip
+
+  # mongodb
+  - SET PATH=C:\mongodb\bin;%PATH%
+  - ps: 'mongo admin --eval "db.runCommand({setParameter: 1, textSearchEnabled: true});"'
+
+  #  MySql
+  # odo and mysql don't play nicely on win32
+  # - SET PATH=C:\Program Files\MySql\MySQL Server 5.7\bin\;%PATH%
+  # - mysql -u root -p"Password12!" -e "CREATE DATABASE IF NOT EXISTS test;"
+  # - mysql -u root -p"Password12!" -e "CREATE USER 'appveyor'@'localhost';"
+  # - mysql -u root -p"Password12!" -e "GRANT ALL PRIVILEGES ON *.* TO 'appveyor'@'localhost';"
+
+  # Postgresql
+  - SET PGUSER=postgres
+  - SET PGPASSWORD=Password12!
+  - SET PATH=C:\Program Files\PostgreSQL\9.3\bin\;%PATH%
+  - createdb test
+
+  # install the frozen ci dependencies
+  - pip install -e .[ci]
+
+  # blaze required deps
+  - pip install git+https://github.com/blaze/datashape
+  - pip install git+https://github.com/blaze/odo
+
+  - python setup.py develop
+
+test_script:
+  - conda list
+  - py.test blaze

--- a/blaze/compute/tests/test_mongo_compute.py
+++ b/blaze/compute/tests/test_mongo_compute.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import sys
 import pytest
 pymongo = pytest.importorskip('pymongo')
 
@@ -268,30 +269,35 @@ def test_datetime_handling(events):
                        events)) == set([2, 3])
 
 
+@xfail(sys.platform == 'win32', reason='on win32, results are backwards')
 def test_summary_kwargs(bank):
     expr = by(t.name, total=t.amount.sum(), avg=t.amount.mean())
     result = compute(expr, bank)
     assert result == [('Bob', 200.0, 600), ('Alice', 150.0, 300)]
 
 
+@xfail(sys.platform == 'win32', reason='on win32, results are backwards')
 def test_summary_count(bank):
     expr = by(t.name, how_many=t.amount.count())
     result = compute(expr, bank)
     assert result == [('Bob', 3), ('Alice', 2)]
 
 
+@xfail(sys.platform == 'win32', reason='on win32, results are backwards')
 def test_summary_arith(bank):
     expr = by(t.name, add_one_and_sum=(t.amount + 1).sum())
     result = compute(expr, bank)
     assert result == [('Bob', 603), ('Alice', 302)]
 
 
+@xfail(sys.platform == 'win32', reason='on win32, results are backwards')
 def test_summary_arith_min(bank):
     expr = by(t.name, add_one_and_sum=(t.amount + 1).min())
     result = compute(expr, bank)
     assert result == [('Bob', 101), ('Alice', 101)]
 
 
+@xfail(sys.platform == 'win32', reason='on win32, results are backwards')
 def test_summary_arith_max(bank):
     expr = by(t.name, add_one_and_sum=(t.amount + 1).max())
     result = compute(expr, bank)

--- a/blaze/compute/tests/test_mysql_compute.py
+++ b/blaze/compute/tests/test_mysql_compute.py
@@ -3,9 +3,15 @@ from __future__ import absolute_import, print_function, division
 from getpass import getuser
 
 import pytest
+import sys
 
 sa = pytest.importorskip('sqlalchemy')
 pytest.importorskip('pymysql')
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == 'win32',
+    reason='odo and mysql don\'t play nicely on win32'
+)
 
 from odo import odo, drop, discover
 


### PR DESCRIPTION
Hello,

I put together a appveyor.yml if you would like to use it. 

This built successfully for me here:

https://ci.appveyor.com/project/thequackdaddy/blaze

A few caveats:
* mysql doesn't seem to work well on win32. I *think* the problem has something to do with loading data. (in most documentations that I've seen, mysql on win32 uses pathnames like `C:\mydir\myfile.csv` while I think the way the test suite and `odo` work is that they send pathnames like `C:\\mydir\\myfile.csv`. So I've skipped all those tests.
* mongodb fails a handful of tests. I've xfailed them in this version for now. 

Here's a sample mongo fail... 

```
bank = Collection(Database(MongoClient('localhost', 27017), 'test_db'), 'bank')
    def test_summary_arith_max(bank):
        expr = by(t.name, add_one_and_sum=(t.amount + 1).max())
        result = compute(expr, bank)
>       assert result == [('Bob', 301), ('Alice', 201)]
E       assert [('Alice', 201), ('Bob', 301)] == [('Bob', 301), ('Alice', 201)]
E         At index 0 diff: ('Alice', 201) != ('Bob', 301)
E         Full diff:
E         - [('Alice', 201), ('Bob', 301)]
E         + [('Bob', 301), ('Alice', 201)]
```

A more detailed fail is available here:

https://ci.appveyor.com/project/thequackdaddy/blaze/build/1.0.5

Ultimately (in a separate PR) I'd like to get mssql testing added which is why I'm submitting this. 

Thanks!