### PR TITLE
MAINT; Dask 0.13 seems to require dtypes now

### DIFF
--- a/blaze/compute/dask.py
+++ b/blaze/compute/dask.py
@@ -36,7 +36,8 @@ try:
         func = get_numba_ufunc(expr)
         return atop(func,
                     expr_inds,
-                    *concat((dat, tuple(range(ndim(dat))[::-1])) for dat in data))
+                    *concat((dat, tuple(range(ndim(dat))[::-1])) for dat in data),
+                    dtype=data[-1].dtype)
 
     def optimize_array(expr, *data):
         return broadcast_collect(
@@ -67,12 +68,12 @@ def compute_up(expr, data, **kwargs):
 
     inds = tuple(range(ndim(leaf)))
     tmp = atop(curry(compute_it, chunk_expr, [chunk], **kwargs), inds, data,
-               inds)
+               inds, dtype=data.dtype)
 
     return atop(compose(curry(compute_it, agg_expr, [agg], **kwargs),
                         curry(_concatenate2, axes=expr.axis)),
                 tuple(i for i in inds if i not in expr.axis),
-                tmp, inds)
+                tmp, inds, dtype=tmp.dtype)
 
 
 @dispatch(Transpose, Array)

--- a/blaze/compute/tests/test_dask.py
+++ b/blaze/compute/tests/test_dask.py
@@ -92,7 +92,7 @@ def test_ragged_blockdims():
            ('x', 1, 0): np.ones((5, 2)),
            ('x', 1, 1): np.ones((5, 3))}
 
-    a = Array(dsk, 'x', chunks=[(2, 5), (2, 3)], shape=(7, 5))
+    a = Array(dsk, 'x', chunks=[(2, 5), (2, 3)], shape=(7, 5), dtype=int)
     s = symbol('s', '7 * 5 * int')
 
     assert compute(s.sum(axis=0), a).chunks == ((2, 3),)


### PR DESCRIPTION
dask 0.13 requires dtypes in the arrays

See here:
https://github.com/dask/dask/commit/bd30288067721551611c234f945e3812bf9e6a24

Obviously, appveyor will fail because appveyor.yml isn't in this branch. 

travis builds fine though