### PR TITLE
DOC: Fix docstrings for expressions module.

### DIFF
--- a/blaze/expr/expressions.py
+++ b/blaze/expr/expressions.py
@@ -857,19 +857,24 @@ def binop_inputs(expr):
 class Coalesce(Expr):
     """SQL like coalesce.
 
-    coalesce(a, b) = {
-        a if a is not NULL
-        b otherwise
-    }
+    Behavior::
+
+        coalesce(a, b) = {
+            a if a is not NULL
+            b otherwise
+        }
 
     Examples
     --------
     >>> coalesce(1, 2)
     1
+
     >>> coalesce(1, None)
     1
+
     >>> coalesce(None, 2)
     2
+
     >>> coalesce(None, None) is None
     True
     """
@@ -979,7 +984,7 @@ def drop_field(expr, field, *fields):
 
     See Also
     --------
-    :func:`~blaze.expr.expression.projection`
+    :func:`blaze.expr.expressions.projection`
     """
     to_remove = set((field,)).union(fields)
     new_fields = []

--- a/blaze/expr/expressions.py
+++ b/blaze/expr/expressions.py
@@ -857,7 +857,7 @@ def binop_inputs(expr):
 class Coalesce(Expr):
     """SQL like coalesce.
 
-    Behavior::
+    .. code-block:: python::
 
         coalesce(a, b) = {
             a if a is not NULL

--- a/blaze/expr/expressions.py
+++ b/blaze/expr/expressions.py
@@ -857,7 +857,7 @@ def binop_inputs(expr):
 class Coalesce(Expr):
     """SQL like coalesce.
 
-    .. code-block:: python::
+    .. code-block python
 
         coalesce(a, b) = {
             a if a is not NULL


### PR DESCRIPTION
Fix the reference to `projection` function, which was a documentation build
error.

Also, change docstring for `Coalesce` to clean up warnings on indentation and
lines between examples.

Discovered while building docs via `make info`.