### PR TITLE
MAINT: Move type predicates into dedicated module.

### DIFF
--- a/blaze/compute/tests/test_mysql_compute.py
+++ b/blaze/compute/tests/test_mysql_compute.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from blaze import symbol, compute
 from blaze.utils import example, normalize
-from blaze.interactive import iscoretype, iscorescalar, iscoresequence
+from blaze.types import iscoretype, iscorescalar, iscoresequence
 
 
 @pytest.yield_fixture(scope='module')

--- a/blaze/compute/tests/test_postgresql_compute.py
+++ b/blaze/compute/tests/test_postgresql_compute.py
@@ -33,7 +33,7 @@ from blaze import (
     symbol,
     transform,
 )
-from blaze.interactive import iscorescalar
+from blaze.types import iscorescalar
 from blaze.utils import example, normalize
 
 

--- a/blaze/compute/tests/test_sparksql.py
+++ b/blaze/compute/tests/test_sparksql.py
@@ -24,7 +24,7 @@ import numpy as np
 import pandas as pd
 import pandas.util.testing as tm
 from blaze import compute, symbol, into, by, sin, exp, cos, tan, join
-from blaze.interactive import iscorescalar
+from blaze.types import iscorescalar
 
 from pyspark.sql import DataFrame as SparkDataFrame
 

--- a/blaze/interactive.py
+++ b/blaze/interactive.py
@@ -27,6 +27,7 @@ from .expr import Expr, Symbol, ndim
 from .expr.expressions import sanitized_dshape
 from .dispatch import dispatch
 from .compatibility import _strtypes
+from .types import iscoretype
 
 
 __all__ = ['into', 'to_html', 'data']
@@ -426,24 +427,6 @@ def convert_base(typ, x):
         return typ(x)
     except:
         return typ(odo(x, typ))
-
-
-CORE_SCALAR_TYPES = (float, decimal.Decimal, int, bool, str, Timestamp,
-                     datetime.date, datetime.timedelta)
-CORE_SEQUENCE_TYPES = (list, dict, tuple, set, Series, DataFrame, np.ndarray)
-CORE_TYPES = CORE_SCALAR_TYPES + CORE_SEQUENCE_TYPES
-
-
-def iscorescalar(x):
-    return isinstance(x, CORE_SCALAR_TYPES)
-
-
-def iscoresequence(x):
-    return isinstance(x, CORE_SEQUENCE_TYPES)
-
-
-def iscoretype(x):
-    return isinstance(x, CORE_TYPES)
 
 
 Expr.__array__ = intonumpy

--- a/blaze/tests/test_interactive.py
+++ b/blaze/tests/test_interactive.py
@@ -22,9 +22,6 @@ from blaze.interactive import (
     concrete_head,
     data,
     expr_repr,
-    iscorescalar,
-    iscoresequence,
-    iscoretype,
     to_html,
 )
 from blaze.utils import tmpfile, example, normalize
@@ -564,40 +561,3 @@ def test_isidentical_regr():
                            np.ndarray)])
 def test_coerce_core(data, dshape, exp_type):
     assert isinstance(coerce_core(data, dshape), exp_type)
-
-
-@pytest.mark.parametrize('data,res',
-                         [(1, True),
-                          (1.1, True),
-                          ("foo", True),
-                          ([1, 2], False),
-                          ((1, 2), False),
-                          (pd.Series([1, 2]), False)])
-def test_iscorescalar(data, res):
-    assert iscorescalar(data) == res
-
-
-@pytest.mark.parametrize('data,res',
-                         [(1, False),
-                          ("foo", False),
-                          ([1, 2], True),
-                          ((1, 2), True),
-                          (pd.Series([1, 2]), True),
-                          (pd.DataFrame([[1, 2], [3, 4]]), True),
-                          (np.ndarray([1, 2]), True),
-                          (into(da.core.Array, [1, 2], chunks=(10,)), False)])
-def test_iscoresequence(data, res):
-    assert iscoresequence(data) == res
-
-
-@pytest.mark.parametrize('data,res',
-                         [(1, True),
-                          ("foo", True),
-                          ([1, 2], True),
-                          ((1, 2), True),
-                          (pd.Series([1, 2]), True),
-                          (pd.DataFrame([[1, 2], [3, 4]]), True),
-                          (np.ndarray([1, 2]), True),
-                          (into(da.core.Array, [1, 2], chunks=(10,)), False)])
-def test_iscoretype(data, res):
-    assert iscoretype(data) == res

--- a/blaze/tests/test_types.py
+++ b/blaze/tests/test_types.py
@@ -1,0 +1,48 @@
+import dask.array as da
+import numpy as np
+import pandas as pd
+import pytest
+
+from blaze.interactive import into
+from blaze.types import (
+    iscorescalar,
+    iscoresequence,
+    iscoretype,
+)
+
+
+@pytest.mark.parametrize('data,res',
+                         [(1, True),
+                          (1.1, True),
+                          ("foo", True),
+                          ([1, 2], False),
+                          ((1, 2), False),
+                          (pd.Series([1, 2]), False)])
+def test_iscorescalar(data, res):
+    assert iscorescalar(data) == res
+
+
+@pytest.mark.parametrize('data,res',
+                         [(1, False),
+                          ("foo", False),
+                          ([1, 2], True),
+                          ((1, 2), True),
+                          (pd.Series([1, 2]), True),
+                          (pd.DataFrame([[1, 2], [3, 4]]), True),
+                          (np.ndarray([1, 2]), True),
+                          (into(da.core.Array, [1, 2], chunks=(10,)), False)])
+def test_iscoresequence(data, res):
+    assert iscoresequence(data) == res
+
+
+@pytest.mark.parametrize('data,res',
+                         [(1, True),
+                          ("foo", True),
+                          ([1, 2], True),
+                          ((1, 2), True),
+                          (pd.Series([1, 2]), True),
+                          (pd.DataFrame([[1, 2], [3, 4]]), True),
+                          (np.ndarray([1, 2]), True),
+                          (into(da.core.Array, [1, 2], chunks=(10,)), False)])
+def test_iscoretype(data, res):
+    assert iscoretype(data) == res

--- a/blaze/types.py
+++ b/blaze/types.py
@@ -1,0 +1,38 @@
+import datetime
+import decimal
+
+import numpy as np
+import pandas as pd
+
+CORE_SCALAR_TYPES = (
+    float,
+    decimal.Decimal,
+    int,
+    bool,
+    str,
+    pd.Timestamp,
+    datetime.date,
+    datetime.timedelta
+)
+CORE_SEQUENCE_TYPES = (
+    list,
+    dict,
+    tuple,
+    set,
+    pd.Series,
+    pd.DataFrame,
+    np.ndarray
+)
+CORE_TYPES = CORE_SCALAR_TYPES + CORE_SEQUENCE_TYPES
+
+
+def iscorescalar(x):
+    return isinstance(x, CORE_SCALAR_TYPES)
+
+
+def iscoresequence(x):
+    return isinstance(x, CORE_SEQUENCE_TYPES)
+
+
+def iscoretype(x):
+    return isinstance(x, CORE_TYPES)


### PR DESCRIPTION
Break out `iscorescalar`, `iscoresequence`, and `iscoretype` into a module
dedicated to type checking.

Putting these functions in their own module helps avoid an import cycle while
breaking out other components from the interactive module.