### PR TITLE
Breakout pieces from interactive.

### DIFF
--- a/blaze/__init__.py
+++ b/blaze/__init__.py
@@ -58,6 +58,7 @@ from .expr import (
 )
 from .expr.arrays import (tensordot, transpose)
 from .expr.functions import *
+from .expr.literal import data
 from .index import create_index
 from .interactive import *
 from .compute.pmap import set_default_pmap

--- a/blaze/compute/literal.py
+++ b/blaze/compute/literal.py
@@ -1,0 +1,26 @@
+from odo import append, drop
+
+from ..compute.core import compute
+from ..dispatch import dispatch
+from ..expr.expressions import Expr
+from ..expr.literal import Data
+
+
+@dispatch(Expr, Data)
+def compute_down(expr, dta, **kwargs):
+    return compute(expr, dta.data, **kwargs)
+
+
+@dispatch(Expr, Data)
+def pre_compute(expr, dta, **kwargs):
+    return pre_compute(expr, dta.data, **kwargs)
+
+
+@dispatch(Data, object)
+def append(a, b, **kwargs):
+    return append(a.data, b, **kwargs)
+
+
+@dispatch(Data)
+def drop(d):
+    return drop(d.data)

--- a/blaze/compute/numpy.py
+++ b/blaze/compute/numpy.py
@@ -7,6 +7,8 @@ from pandas import DataFrame, Series
 from datashape import to_numpy, to_numpy_dtype
 from numbers import Number
 
+from odo import odo
+
 from ..expr import (
     Reduction, Field, Projection, Broadcast, Selection, ndim,
     Distinct, Sort, Tail, Head, Label, ReLabel, Expr, Slice, Join,
@@ -473,3 +475,14 @@ def compute_up(t, data, **kwargs):
         rhs = data
 
     return array_coalesce(t, lhs, rhs)
+
+
+def intonumpy(data, dtype=None, **kwargs):
+    # TODO: Don't ignore other kwargs like copy
+    result = odo(data, np.ndarray)
+    if dtype and result.dtype != dtype:
+        result = result.astype(dtype)
+    return result
+
+
+Expr.__array__ = intonumpy

--- a/blaze/compute/tests/test_comprehensive.py
+++ b/blaze/compute/tests/test_comprehensive.py
@@ -6,8 +6,7 @@ import numpy as np
 from pandas import DataFrame
 from odo import into
 from datashape.predicates import isscalar, iscollection, isrecord
-from blaze.expr import symbol, by
-from blaze.interactive import data
+from blaze.expr import symbol, by, data
 from blaze.compute import compute
 from blaze.expr.functions import sin, exp
 

--- a/blaze/expr/__init__.py
+++ b/blaze/expr/__init__.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 from .core import *
 from .expressions import *
+from .literal import *
 from .strings import *
 from .datetime import *
 from .math import *

--- a/blaze/expr/collections.py
+++ b/blaze/expr/collections.py
@@ -47,8 +47,8 @@ from .expressions import (
     varargsexpr,
 )
 from .utils import maxshape
+from .literal import data
 from ..compatibility import zip_longest, _strtypes
-from ..interactive import data
 from ..utils import listpack
 
 

--- a/blaze/expr/literal.py
+++ b/blaze/expr/literal.py
@@ -1,0 +1,163 @@
+from __future__ import absolute_import, division, print_function
+
+from collections import Iterator, Mapping
+import itertools
+
+import datashape
+from datashape import discover, Tuple, Record, DataShape, var
+from datashape.predicates import (
+    isscalar,
+    isrecord,
+)
+from odo import resource
+from odo.utils import ignoring, copydoc
+
+from ..compatibility import _strtypes
+from ..dispatch import dispatch
+from .expressions import sanitized_dshape, Symbol
+
+__all__ = ['Data', 'data']
+
+
+names = ('_%d' % i for i in itertools.count(1))
+not_an_iterator = []
+
+
+with ignoring(ImportError):
+    import bcolz
+    not_an_iterator.append(bcolz.carray)
+
+
+with ignoring(ImportError):
+    import pymongo
+    not_an_iterator.append(pymongo.collection.Collection)
+    not_an_iterator.append(pymongo.database.Database)
+
+
+class Data(Symbol):
+
+    # NOTE: This docstring is meant to correspond to the ``data()`` API, which
+    # is why the Parameters section doesn't match the arguments to
+    # ``Data.__init__()``.
+
+    """Bind a data resource to a symbol, for use in expressions and
+    computation.
+
+    A ``data`` object presents a consistent view onto a variety of concrete
+    data sources.  Like ``symbol`` objects, they are meant to be used in
+    expressions.  Because they are tied to concrete data resources, ``data``
+    objects can be used with ``compute`` directly, making them convenient for
+    interactive exploration.
+
+    Parameters
+    ----------
+    data_source : object
+        Any type with ``discover`` and ``compute`` implementations
+    fields : list, optional
+        Field or column names, will be inferred from data_source if possible
+    dshape : str or DataShape, optional
+        DataShape describing input data
+    name : str, optional
+        A name for the data.
+
+    Examples
+    --------
+    >>> t = data([(1, 'Alice', 100),
+    ...           (2, 'Bob', -200),
+    ...           (3, 'Charlie', 300),
+    ...           (4, 'Denis', 400),
+    ...           (5, 'Edith', -500)],
+    ...          fields=['id', 'name', 'balance'])
+    >>> t[t.balance < 0].name.peek()
+        name
+    0    Bob
+    1  Edith
+    """
+    _arguments = 'data', 'dshape', '_name'
+
+    def __new__(cls, data, dshape, name=None):
+        return super(Symbol, cls).__new__(
+            cls,
+            data,
+            dshape,
+            name or (
+                next(names)
+                if isrecord(dshape.measure) else None
+            ),
+        )
+
+    def _resources(self):
+        return {self: self.data}
+
+    @classmethod
+    def _static_identity(cls, data, dshape, _name):
+        try:
+            # cannot use isinstance(data, Hashable)
+            # some classes give a false positive
+            hash(data)
+        except TypeError:
+            data = id(data)
+        return cls, data, dshape, _name
+
+    def __repr__(self):
+        fmt = "<'{}' data; _name='{}', dshape='{}'>"
+        return fmt.format(type(self.data).__name__,
+                          self._name,
+                          sanitized_dshape(self.dshape))
+
+
+@copydoc(Data)
+def data(data_source, dshape=None, name=None, fields=None, schema=None, **kwargs):
+    if schema and dshape:
+        raise ValueError("Please specify one of schema= or dshape= keyword"
+                         " arguments")
+
+    if isinstance(data_source, Data):
+        return data(data_source.data, dshape, name, fields, schema, **kwargs)
+
+    if schema and not dshape:
+        dshape = var * schema
+    if dshape and isinstance(dshape, _strtypes):
+        dshape = datashape.dshape(dshape)
+
+    if isinstance(data_source, _strtypes):
+        data_source = resource(data_source, schema=schema, dshape=dshape, **kwargs)
+
+    if (isinstance(data_source, Iterator) and
+            not isinstance(data_source, tuple(not_an_iterator))):
+        data_source = tuple(data_source)
+    if not dshape:
+        dshape = discover(data_source)
+        types = None
+        if isinstance(dshape.measure, Tuple) and fields:
+            types = dshape[1].dshapes
+            schema = Record(list(zip(fields, types)))
+            dshape = DataShape(*(dshape.shape + (schema,)))
+        elif isscalar(dshape.measure) and fields:
+            types = (dshape.measure,) * int(dshape[-2])
+            schema = Record(list(zip(fields, types)))
+            dshape = DataShape(*(dshape.shape[:-1] + (schema,)))
+        elif isrecord(dshape.measure) and fields:
+            ds = discover(data_source)
+            assert isrecord(ds.measure)
+            names = ds.measure.names
+            if names != fields:
+                raise ValueError('data column names %s\n'
+                                 '\tnot equal to fields parameter %s,\n'
+                                 '\tuse data(data_source).relabel(%s) to rename '
+                                 'fields' % (names,
+                                             fields,
+                                             ', '.join('%s=%r' % (k, v)
+                                                       for k, v in
+                                                       zip(names, fields))))
+            types = dshape.measure.types
+            schema = Record(list(zip(fields, types)))
+            dshape = DataShape(*(dshape.shape + (schema,)))
+
+    ds = datashape.dshape(dshape)
+    return Data(data_source, ds, name)
+
+
+@dispatch(Data, Mapping)
+def _subs(o, d):
+    return o

--- a/blaze/index.py
+++ b/blaze/index.py
@@ -1,7 +1,8 @@
 from .dispatch import dispatch
 from .compatibility import basestring
-from blaze.interactive import _Data
-from blaze.interactive import data as bz_data
+from blaze.expr.literal import Data
+from blaze.expr.literal import data as bz_data
+
 
 @dispatch(object, (basestring, list, tuple))
 def create_index(t, column_name_or_names, name=None):
@@ -34,7 +35,7 @@ def create_index(t, column_name_or_names, name=None):
     raise NotImplementedError("create_index not implemented for type %r" %
                               type(t).__name__)
 
-@dispatch(_Data, (basestring, list, tuple))
+@dispatch(Data, (basestring, list, tuple))
 def create_index(dta, column_name_or_names, name=None, **kwargs):
     return create_index(dta.data, column_name_or_names, name=name, **kwargs)
 

--- a/blaze/server/server.py
+++ b/blaze/server/server.py
@@ -28,8 +28,7 @@ from blaze import compute, resource
 from blaze.compatibility import ExitStack, u8
 from blaze.compute import compute_up
 from .serialization import json, all_formats
-from ..interactive import _Data
-from ..expr import Expr, symbol, utils as expr_utils, Symbol
+from ..expr import Data, Expr, symbol, utils as expr_utils, Symbol
 
 
 __all__ = 'Server', 'to_tree', 'from_tree', 'expr_md5'
@@ -335,9 +334,9 @@ class Server(object):
                  loglevel='WARNING',
                  log_exception_formatter=_default_log_exception_formatter):
         if isinstance(data, collections.Mapping):
-            data = valmap(lambda v: v.data if isinstance(v, _Data) else v,
+            data = valmap(lambda v: v.data if isinstance(v, Data) else v,
                           data)
-        elif isinstance(data, _Data):
+        elif isinstance(data, Data):
             data = data._resources()
         app = self.app = FlaskWithExceptionFormatting('blaze.server.server',
                                                       log_exception_formatter=log_exception_formatter)
@@ -458,7 +457,7 @@ def to_tree(expr, names=None):
         return [to_tree(arg, names=names) for arg in expr]
     if isinstance(expr, expr_utils._slice):
         return to_tree(expr.as_slice(), names=names)
-    elif isinstance(expr, _Data):
+    elif isinstance(expr, Data):
         return to_tree(symbol(u8(expr._name), expr.dshape), names)
     elif isinstance(expr, Expr):
         return {u'op': u8(type(expr).__name__),

--- a/blaze/server/spider.py
+++ b/blaze/server/spider.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 
 import yaml
 
-from blaze.interactive import data as bz_data
+from blaze.expr import data as bz_data
 from odo.utils import ignoring
 
 from .server import Server, DEFAULT_PORT

--- a/blaze/tests/test_interactive.py
+++ b/blaze/tests/test_interactive.py
@@ -4,7 +4,6 @@ import pickle
 import sys
 from types import MethodType
 
-import dask.array as da
 from datashape import dshape
 from datashape.util.testing import assert_dshape_equal
 import pandas as pd
@@ -15,12 +14,10 @@ from odo import into, append
 from odo.backends.csv import CSV
 
 from blaze import discover, transform
-from blaze.expr import symbol
+from blaze.compute import compute
+from blaze.expr import data, symbol
 from blaze.interactive import (
-    coerce_core,
-    compute,
     concrete_head,
-    data,
     expr_repr,
     to_html,
 )
@@ -539,25 +536,3 @@ def test_isidentical_regr():
     tdata = np.array([(np.nan,), (np.nan,)], dtype=[('a', 'float64')])
     ds = data(tdata)
     assert ds.a.isidentical(ds.a)
-
-
-@pytest.mark.parametrize('data,dshape,exp_type',
-                         [(1, symbol('x', 'int').dshape, int),
-                          # test 1-d to series
-                          (into(da.core.Array, [1, 2], chunks=(10,)),
-                           dshape('2 * int'),
-                           pd.Series),
-                          # test 2-d tabular to dataframe
-                          (into(da.core.Array,
-                                [{'a': 1, 'b': 2}, {'a': 3, 'b': 4}],
-                                chunks=(10,)),
-                           dshape('2 * {a: int, b: int}'),
-                           pd.DataFrame),
-                          # test 2-d non tabular to ndarray
-                          (into(da.core.Array,
-                                [[1, 2], [3, 4]],
-                                chunks=(10, 10)),
-                           dshape('2 *  2 * int'),
-                           np.ndarray)])
-def test_coerce_core(data, dshape, exp_type):
-    assert isinstance(coerce_core(data, dshape), exp_type)

--- a/blaze/tests/test_types.py
+++ b/blaze/tests/test_types.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from blaze.interactive import into
+from blaze.compute.core import into
 from blaze.types import (
     iscorescalar,
     iscoresequence,


### PR DESCRIPTION

    MAINT: Move expr and compute pieces out interactive.

    Move the `_Data` class and rename it to `Data`.
    (A soon to follow patch will add a `Literal` class from which `Data` will
    inherit, and change dispatches to use `Literal`.)

    Also, move compute and coerce functions into compute.core.

    This is part of the effort of supporting a literal type which is importable from
    expr instead of interactive.
