### PR TITLE
ENH: Allow to_tree to render a literal.

### DIFF
--- a/blaze/compute/__init__.py
+++ b/blaze/compute/__init__.py
@@ -1,3 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
 from .core import compute, compute_up
+# Import literal module to register contained dispatches.
+from . import literal  # noqa

--- a/blaze/compute/core.py
+++ b/blaze/compute/core.py
@@ -24,7 +24,16 @@ from toolz import first, unique, assoc
 from toolz.utils import no_default
 
 from ..compatibility import basestring
-from ..expr import Expr, Field, Literal, Symbol, symbol, Join, Cast
+from ..expr import (
+    BoundSymbol,
+    Cast,
+    Expr,
+    Field,
+    Join,
+    Literal,
+    Symbol,
+    symbol,
+)
 from ..dispatch import dispatch
 from ..types import iscoretype
 
@@ -82,7 +91,7 @@ def compute_down(expr, **kwargs):
 
     inputs match up to leaves of the expression
     """
-    return expr
+    raise NotImplementedError()
 
 
 def issubtype(a, b):
@@ -156,9 +165,10 @@ def top_then_bottom_then_top_again_etc(expr, scope, **kwargs):
     if not hasattr(expr, '_leaves'):
         return expr
 
-    leaf_exprs = list(expr._leaves())
-    leaf_data = [scope.get(leaf) for leaf in leaf_exprs]
-
+    leaf_data = (
+        scope.get(leaf) for leaf in expr._leaves()
+        if not isinstance(leaf, Literal)
+    )
     # 1. See if we have a direct computation path with compute_down
     try:
         return compute_down(expr, *leaf_data, **kwargs)
@@ -172,9 +182,10 @@ def top_then_bottom_then_top_again_etc(expr, scope, **kwargs):
     optimize_ = kwargs.get('optimize', optimize)
     pre_compute_ = kwargs.get('pre_compute', pre_compute)
     if pre_compute_:
-        scope3 = dict((e, pre_compute_(e, datum,
-                                       **assoc(kwargs, 'scope', scope2)))
-                      for e, datum in scope2.items())
+        scope3 = {
+            e: pre_compute_(e, datum, **assoc(kwargs, 'scope', scope2))
+            for e, datum in scope2.items()
+        }
     else:
         scope3 = scope2
     if optimize_:
@@ -349,26 +360,14 @@ def swap_resources_into_scope(expr, scope):
     --------
 
     >>> from blaze import data
-    >>> t = data([1, 2, 3], dshape='3 * int', name='t')
+    >>> t = data([1, 2, 3], dshape='3 * int32', name='t')
     >>> swap_resources_into_scope(t.head(2), {})
-    (t.head(2), {<`t` symbol; dshape='3 * int32'>: [1, 2, 3]})
-
-    >>> expr, scope = _
-    >>> list(scope.keys())[0]._resources()
-    {}
+    {<'list' data; _name='t', dshape='3 * int32'>: [1, 2, 3]}
     """
-    resources = expr._resources()
-    symbol_dict = dict((t, symbol(t._name, t.dshape)) for t in resources)
-    resources = dict((symbol_dict[k], v) for k, v in resources.items())
-    other_scope = dict((k, v) for k, v in scope.items()
-                       if k not in symbol_dict)
-    new_scope = toolz.merge(resources, other_scope)
-    expr = expr._subs(symbol_dict)
-
-    return expr, new_scope
+    return toolz.merge(expr._resources(), scope)
 
 
-@dispatch((object, type, str, unicode), Literal)
+@dispatch((object, type, str, unicode), BoundSymbol)
 def into(a, b, **kwargs):
     return into(a, b.data, **kwargs)
 
@@ -422,31 +421,31 @@ def compute(expr, d, return_type=no_default, **kwargs):
     optimize_ = kwargs.get('optimize', optimize)
     pre_compute_ = kwargs.get('pre_compute', pre_compute)
     post_compute_ = kwargs.get('post_compute', post_compute)
-    expr2, d2 = swap_resources_into_scope(expr, d)
+    d2 = swap_resources_into_scope(expr, d)
     if pre_compute_:
         d3 = dict(
             (e, pre_compute_(e, dat, **kwargs))
             for e, dat in d2.items()
-            if e in expr2
+            if e in expr
         )
     else:
         d3 = d2
 
     if optimize_:
         try:
-            expr3 = optimize_(expr2, *[v for e, v in d3.items() if e in expr2])
-            _d = dict(zip(expr2._leaves(), expr3._leaves()))
+            expr2 = optimize_(expr, *[v for e, v in d3.items() if e in expr])
+            _d = dict(zip(expr._leaves(), expr2._leaves()))
             d4 = dict((e._subs(_d), d) for e, d in d3.items())
         except NotImplementedError:
-            expr3 = expr2
+            expr2 = expr
             d4 = d3
     else:
-        expr3 = expr2
+        expr2 = expr
         d4 = d3
 
-    result = top_then_bottom_then_top_again_etc(expr3, d4, **kwargs)
+    result = top_then_bottom_then_top_again_etc(expr2, d4, **kwargs)
     if post_compute_:
-        result = post_compute_(expr3, result, scope=d4)
+        result = post_compute_(expr2, result, scope=d4)
 
     # return the backend's native response
     if return_type is no_default:
@@ -459,7 +458,7 @@ def compute(expr, d, return_type=no_default, **kwargs):
         result = coerce_core(result, expr.dshape)
     # user specified type
     elif isinstance(return_type, type):
-        result = into(return_type, result, dshape=expr3.dshape)
+        result = into(return_type, result, dshape=expr2.dshape)
     elif return_type != 'native':
         raise ValueError(
             "Invalid return_type passed to compute: {}".format(return_type),
@@ -482,7 +481,11 @@ def compute_single_object(expr, o, **kwargs):
     >>> list(compute(deadbeats, data))
     ['Bob', 'Charlie']
     """
-    ts = set([x for x in expr._subterms() if isinstance(x, Symbol)])
+    resources = expr._resources()
+    ts = set(expr._leaves()) - set(resources)
+    if not ts and o in resources.values():
+        # the data is already bound to an expression
+        return compute(expr, **kwargs)
     if len(ts) == 1:
         return compute(expr, {first(ts): o}, **kwargs)
     else:

--- a/blaze/compute/literal.py
+++ b/blaze/compute/literal.py
@@ -3,24 +3,24 @@ from odo import append, drop
 from ..compute.core import compute
 from ..dispatch import dispatch
 from ..expr.expressions import Expr
-from ..expr.literal import Literal
+from ..expr.literal import BoundSymbol
 
 
-@dispatch(Expr, Literal)
-def compute_down(expr, dta, **kwargs):
-    return compute(expr, dta.data, **kwargs)
+@dispatch(Expr, BoundSymbol)
+def compute_down(expr, data, **kwargs):
+    return compute(expr, data.data, **kwargs)
 
 
-@dispatch(Expr, Literal)
-def pre_compute(expr, dta, **kwargs):
-    return pre_compute(expr, dta.data, **kwargs)
+@dispatch(Expr, BoundSymbol)
+def pre_compute(expr, data, **kwargs):
+    return pre_compute(expr, data.data, **kwargs)
 
 
-@dispatch(Literal, object)
+@dispatch(BoundSymbol, object)
 def append(a, b, **kwargs):
     return append(a.data, b, **kwargs)
 
 
-@dispatch(Literal)
+@dispatch(BoundSymbol)
 def drop(d):
     return drop(d.data)

--- a/blaze/compute/pandas.py
+++ b/blaze/compute/pandas.py
@@ -46,6 +46,7 @@ try:
     DaskDataFrame = dd.DataFrame
     DaskSeries = dd.Series
 except ImportError:
+    dd = None
     DaskDataFrame = pd.DataFrame
     DaskSeries = pd.Series
 
@@ -681,6 +682,9 @@ def _merge(module):
     module : module
         Either ``pandas`` or ``dask``.
     """
+    if module is None:
+        return
+
     @dispatch(Merge, VarArgs[module.Series, base])
     def compute_up(expr, args, **kwargs):
         """Optimized handler when we know the sequence doesn't contain tabular

--- a/blaze/compute/tests/test_core_compute.py
+++ b/blaze/compute/tests/test_core_compute.py
@@ -4,6 +4,7 @@ import pytest
 import operator
 
 from datashape import discover, dshape
+from datashape.util.testing import assert_dshape_equal
 
 from blaze.compute.core import (
     coerce_core,
@@ -97,21 +98,22 @@ def test_swap_resources_into_scope():
 
     from blaze import data
     t = data([1, 2, 3], dshape='3 * int', name='t')
-    expr, scope = swap_resources_into_scope(t.head(2), {t: t.data})
+    scope = swap_resources_into_scope(t.head(2), {})
 
     assert t._resources()
-    assert not expr._resources()
-
-    assert t not in scope
+    assert t in scope
 
 
 def test_compute_up_on_dict():
     d = {'a': [1, 2, 3], 'b': [4, 5, 6]}
 
-    assert str(discover(d)) == str(dshape('{a: 3 * int64, b: 3 * int64}'))
+    assert_dshape_equal(
+        discover(d),
+        dshape('{a: 3 * int64, b: 3 * int64}').measure,
+        check_record_order=False,  # dict order undefined
+    )
 
     s = symbol('s', discover(d))
-
     assert compute(s.a, {s: d}) == [1, 2, 3]
 
 

--- a/blaze/compute/tests/test_dask.py
+++ b/blaze/compute/tests/test_dask.py
@@ -92,7 +92,7 @@ def test_ragged_blockdims():
            ('x', 1, 0): np.ones((5, 2)),
            ('x', 1, 1): np.ones((5, 3))}
 
-    a = Array(dsk, 'x', chunks=[(2, 5), (2, 3)], shape=(7, 5))
+    a = Array(dsk, 'x', chunks=[(2, 5), (2, 3)], shape=(7, 5), dtype='int64')
     s = symbol('s', '7 * 5 * int')
 
     assert compute(s.sum(axis=0), a).chunks == ((2, 3),)

--- a/blaze/expr/core.py
+++ b/blaze/expr/core.py
@@ -236,9 +236,7 @@ class Node(object):
         return subs(self, d)
 
     def _resources(self):
-        return toolz.merge(
-            arg._resources() for arg in self._inputs if isinstance(arg, Node)
-        )
+        return toolz.merge(arg._resources() for arg in self._inputs)
 
     def _subterms(self):
         return subterms(self)

--- a/blaze/index.py
+++ b/blaze/index.py
@@ -1,7 +1,6 @@
 from .dispatch import dispatch
 from .compatibility import basestring
-from blaze.expr.literal import Literal
-from blaze.expr.literal import data as bz_data
+from blaze.expr.literal import BoundSymbol, data as bz_data
 
 
 @dispatch(object, (basestring, list, tuple))
@@ -35,7 +34,7 @@ def create_index(t, column_name_or_names, name=None):
     raise NotImplementedError("create_index not implemented for type %r" %
                               type(t).__name__)
 
-@dispatch(Literal, (basestring, list, tuple))
+@dispatch(BoundSymbol, (basestring, list, tuple))
 def create_index(dta, column_name_or_names, name=None, **kwargs):
     return create_index(dta.data, column_name_or_names, name=name, **kwargs)
 

--- a/blaze/tests/test_interactive.py
+++ b/blaze/tests/test_interactive.py
@@ -15,7 +15,7 @@ from odo.backends.csv import CSV
 
 from blaze import discover
 from blaze.compute import compute
-from blaze.expr import data, literal, symbol
+from blaze.expr import data, symbol
 from blaze.interactive import (
     concrete_head,
     expr_repr,
@@ -305,11 +305,11 @@ def test_scalar_sql_compute():
 
 
 def test_no_name_for_simple_data():
-    d = literal([1, 2, 3])
+    d = data([1, 2, 3])
     assert expr_repr(d) == '    \n0  1\n1  2\n2  3'
     assert not d._name
 
-    d = literal(1)
+    d = data(1)
     assert not d._name
     assert expr_repr(d) == '1'
 


### PR DESCRIPTION
So that input literals which are not bound to a data resource, can be sent to
the server. e.g. a frozenset which is the `_keys` of an `IsIn` statement.