### PR TITLE
ENH: Allow an expr as the `_keys` of an IsIn.

### DIFF
--- a/blaze/compute/numpy.py
+++ b/blaze/compute/numpy.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+from collections import Iterable
 import datetime
 
 import numpy as np
@@ -435,9 +436,9 @@ def compute_up(expr, lhs, rhs, **kwargs):
     return np.tensordot(lhs, rhs, axes=[expr._left_axes, expr._right_axes])
 
 
-@dispatch(IsIn, np.ndarray)
-def compute_up(expr, data, **kwargs):
-    return np.in1d(data, tuple(expr._keys))
+@dispatch(IsIn, np.ndarray, Iterable)
+def compute_up(expr, data, keys, **kwargs):
+    return np.in1d(data, keys)
 
 
 @compute_up.register(Join, DataFrame, np.ndarray)

--- a/blaze/compute/pandas.py
+++ b/blaze/compute/pandas.py
@@ -21,7 +21,7 @@ import fnmatch
 import itertools
 from distutils.version import LooseVersion
 import warnings
-from collections import defaultdict
+from collections import defaultdict, Iterable
 
 import numpy as np
 
@@ -845,9 +845,9 @@ def compute_up(expr, data, **kwargs):
                   name=expr._name)
 
 
-@dispatch(IsIn, (Series, DaskSeries))
-def compute_up(expr, data, **kwargs):
-    return data.isin(expr._keys)
+@dispatch(IsIn, (Series, DaskSeries), Iterable)
+def compute_up(expr, data, keys, **kwargs):
+    return data.isin(keys)
 
 
 @dispatch(Coerce, (Series, DaskSeries))

--- a/blaze/compute/python.py
+++ b/blaze/compute/python.py
@@ -11,7 +11,7 @@
 """
 from __future__ import absolute_import, division, print_function
 
-from collections import Mapping
+from collections import Iterable, Mapping
 import itertools
 import numbers
 import fnmatch
@@ -189,11 +189,6 @@ def rowfunc(t):
 def rowfunc(t):
     index = t._child.fields.index(t._name)
     return lambda x, index=index: x[index]
-
-
-@dispatch(IsIn)
-def rowfunc(t):
-    return t._keys.__contains__
 
 
 @dispatch(Broadcast)

--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -1521,32 +1521,53 @@ def post_compute(_, s, **kwargs):
     return select(s)
 
 
-@dispatch(IsIn, ColumnElement, (Iterable, Selectable))
+@dispatch((Iterable, Selectable))
+def _coerce_op_input(i):
+    """Make input to SQLAlchemy operator an amenable type.
+
+    Parameters
+    ----------
+    i : (Iterable, Selectable)
+       The iterable or selectable to coerce.
+
+    Returns
+    -------
+    coerced_input : (Iterable, Selectable)
+       The iterable or selectable passed to the function.
+       These types are already the amenable types.
+    """
+    return i
+
+
+@dispatch(ColumnElement)
+def _coerce_op_input(i):
+    """Make input to SQLAlchemy operator an amenable type.
+
+    Parameters
+    ----------
+    i : ColumnElement
+       The column element to coerce.
+
+    Returns
+    -------
+    coerced_input : sa.selectable.Select
+       A select wrapping the column element.
+    """
+    return select(i)
+
+
+@dispatch(IsIn, ColumnElement, (Iterable, Selectable, ColumnElement))
 def compute_up(expr, data, keys, **kwargs):
-    return data.in_(keys)
+    return data.in_(_coerce_op_input(keys))
 
 
-@dispatch(IsIn, ColumnElement, ColumnElement)
-def compute_up(expr, data, keys, **kwargs):
-    return data.in_(select(keys))
-
-
-@dispatch(IsIn, Selectable, (Iterable, Selectable))
+@dispatch(IsIn, Selectable, (Iterable, Selectable, ColumnElement))
 def compute_up(expr, data, keys, **kwargs):
     assert len(data.columns) == 1, (
         'only 1 column is allowed in a Select in IsIn'
     )
     col, = unsafe_inner_columns(data)
-    return data.where(col.in_(keys))
-
-
-@dispatch(IsIn, Selectable, ColumnElement)
-def compute_up(expr, data, keys, **kwargs):
-    assert len(data.columns) == 1, (
-        'only 1 column is allowed in a Select in IsIn'
-    )
-    col, = unsafe_inner_columns(data)
-    return data.where(col.in_(select(keys)))
+    return data.where(col.in_(_coerce_op_input(keys)))
 
 
 @dispatch(Slice, (Select, Selectable, ColumnElement))

--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -1537,7 +1537,7 @@ def compute_up(expr, data, keys, **kwargs):
         'only 1 column is allowed in a Select in IsIn'
     )
     col, = unsafe_inner_columns(data)
-    return reconstruct_select((col.in_(keys),), data)
+    return data.where(col.in_(keys))
 
 
 @dispatch(IsIn, Selectable, ColumnElement)
@@ -1546,7 +1546,7 @@ def compute_up(expr, data, keys, **kwargs):
         'only 1 column is allowed in a Select in IsIn'
     )
     col, = unsafe_inner_columns(data)
-    return col.in_(select(keys))
+    return data.where(col.in_(select(keys)))
 
 
 @dispatch(Slice, (Select, Selectable, ColumnElement))

--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -1528,7 +1528,7 @@ def compute_up(expr, data, keys, **kwargs):
 
 @dispatch(IsIn, ColumnElement, ColumnElement)
 def compute_up(expr, data, keys, **kwargs):
-    return data.in_(Select([keys]))
+    return data.in_(select(keys))
 
 
 @dispatch(IsIn, Selectable, (Iterable, Selectable))

--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -1567,7 +1567,7 @@ def compute_up(expr, data, keys, **kwargs):
         'only 1 column is allowed in a Select in IsIn'
     )
     col, = unsafe_inner_columns(data)
-    return data.where(col.in_(_coerce_op_input(keys)))
+    return reconstruct_select((col.in_(_coerce_op_input(keys)),), data)
 
 
 @dispatch(Slice, (Select, Selectable, ColumnElement))

--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -1546,7 +1546,7 @@ def compute_up(expr, data, keys, **kwargs):
         'only 1 column is allowed in a Select in IsIn'
     )
     col, = unsafe_inner_columns(data)
-    return col.in_(Select([keys]))
+    return col.in_(select(keys))
 
 
 @dispatch(Slice, (Select, Selectable, ColumnElement))

--- a/blaze/compute/tests/test_mongo_compute.py
+++ b/blaze/compute/tests/test_mongo_compute.py
@@ -408,7 +408,8 @@ def test_interactive_dshape_works(bank, mongo_host_port):
     assert dshape(d.dshape.measure) == dshape('{amount: int64, name: string}')
 
 
-@pytest.mark.xfail(raises=TypeError, reason="IsIn not yet implemented")
+@pytest.mark.xfail(raises=NotImplementedError,
+                   reason="IsIn not yet implemented")
 def test_isin_fails(bank):
     expr = t[t.amount.isin([100])]
     result = compute(expr, bank)

--- a/blaze/compute/tests/test_python_compute.py
+++ b/blaze/compute/tests/test_python_compute.py
@@ -902,6 +902,8 @@ def test_notnull_whole_collection():
         t.notnull
 
 
+@pytest.mark.xfail(raises=NotImplementedError,
+                   reason="IsIn not implemented.")
 @pytest.mark.parametrize('keys', [['Alice'], ['Bob', 'Alice']])
 def test_isin(keys):
     expr = t[t.name.isin(keys)]

--- a/blaze/compute/tests/test_sql_compute.py
+++ b/blaze/compute/tests/test_sql_compute.py
@@ -30,6 +30,7 @@ from blaze.expr import (
     exp,
     floor,
     greatest,
+    isin,
     join,
     least,
     mean,
@@ -1672,7 +1673,7 @@ def test_transform_order():
     assert normalize(str(result)) == normalize(expected)
 
 
-def test_isin():
+def test_isin_literal():
     result = t[t.name.isin(['foo', 'bar'])]
     result_sql_expr = str(compute(result, s, return_type='native'))
     expected = """
@@ -1687,6 +1688,118 @@ def test_isin():
         IN
             (:name_1,
             :name_2)
+    """
+    assert normalize(result_sql_expr) == normalize(expected)
+
+
+def test_not_isin_literal():
+    result = t[~t.name.isin(['foo', 'bar'])]
+    result_sql_expr = str(compute(result, s, return_type='native'))
+    expected = """
+        SELECT
+            accounts.name,
+            accounts.amount,
+            accounts.id
+        FROM
+            accounts
+        WHERE
+            accounts.name
+        NOT IN
+            (:name_1,
+            :name_2)
+    """
+    assert normalize(result_sql_expr) == normalize(expected)
+
+
+def test_isin_expression():
+    metadata = sa.MetaData()
+    lhs = sa.Table('accounts', metadata,
+                   sa.Column('name', sa.String),
+                   sa.Column('amount', sa.Integer))
+
+    rhs = sa.Table('ids', metadata,
+                   sa.Column('name', sa.String),
+                   sa.Column('id', sa.Integer))
+
+    L = symbol('L', 'var * {name: string, amount: int}')
+    R = symbol('R', 'var * {name: string, id: int}')
+    want = L[L.name.isin(R.name)]
+
+    result = compute(want, {L: lhs, R: rhs}, return_type='native')
+    result_sql_expr = str(result)
+    expected = """
+        SELECT
+            accounts.name,
+            accounts.amount
+        FROM
+            accounts
+        WHERE
+            accounts.name
+        IN
+            (SELECT ids.name
+             FROM ids)
+    """
+    assert normalize(result_sql_expr) == normalize(expected)
+
+
+def test_not_isin_expression():
+    metadata = sa.MetaData()
+    lhs = sa.Table('accounts', metadata,
+                   sa.Column('name', sa.String),
+                   sa.Column('amount', sa.Integer))
+
+    rhs = sa.Table('ids', metadata,
+                   sa.Column('name', sa.String),
+                   sa.Column('id', sa.Integer))
+
+    L = symbol('L', 'var * {name: string, amount: int}')
+    R = symbol('R', 'var * {name: string, id: int}')
+    want = L[~L.name.isin(R.name)]
+
+    result = compute(want, {L: lhs, R: rhs}, return_type='native')
+    result_sql_expr = str(result)
+    expected = """
+        SELECT
+            accounts.name,
+            accounts.amount
+        FROM
+            accounts
+        WHERE
+            accounts.name
+        NOT IN
+            (SELECT ids.name
+             FROM ids)
+    """
+    assert normalize(result_sql_expr) == normalize(expected)
+
+
+def test_not_isin_select_expression():
+    metadata = sa.MetaData()
+    lhs = sa.Table('accounts', metadata,
+                   sa.Column('name', sa.String),
+                   sa.Column('amount', sa.Integer))
+
+    rhs = sa.Table('ids', metadata,
+                   sa.Column('name', sa.String),
+                   sa.Column('id', sa.Integer))
+
+    L = symbol('L', 'var * {name: string, amount: int}')
+    R = symbol('R', 'var * {name: string, id: int}')
+    want = L[~L.name.isin(R.name[R.id > 1])]
+
+    result = compute(want, {L: lhs, R: rhs}, return_type='native')
+    result_sql_expr = str(result)
+    expected = """
+        SELECT
+            accounts.name,
+            accounts.amount
+        FROM
+            accounts
+        WHERE
+            accounts.name
+        NOT IN
+            (SELECT ids.name
+             FROM ids where ids.id > :id_1)
     """
     assert normalize(result_sql_expr) == normalize(expected)
 

--- a/blaze/compute/tests/test_sql_compute.py
+++ b/blaze/compute/tests/test_sql_compute.py
@@ -1674,8 +1674,8 @@ def test_transform_order():
 
 
 def test_isin_literal():
-    result = t[t.name.isin(['foo', 'bar'])]
-    result_sql_expr = str(compute(result, s, return_type='native'))
+    expr = t[t.name.isin(['foo', 'bar'])]
+    result_sql_expr = str(compute(expr, s, return_type='native'))
     expected = """
         SELECT
             accounts.name,
@@ -1693,8 +1693,8 @@ def test_isin_literal():
 
 
 def test_not_isin_literal():
-    result = t[~t.name.isin(['foo', 'bar'])]
-    result_sql_expr = str(compute(result, s, return_type='native'))
+    expr = t[~t.name.isin(['foo', 'bar'])]
+    result_sql_expr = str(compute(expr, s, return_type='native'))
     expected = """
         SELECT
             accounts.name,

--- a/blaze/expr/collections.py
+++ b/blaze/expr/collections.py
@@ -47,7 +47,7 @@ from .expressions import (
     varargsexpr,
 )
 from .utils import maxshape
-from .literal import data
+from .literal import data, literal
 from ..compatibility import zip_longest, _strtypes
 from ..utils import listpack
 
@@ -883,9 +883,14 @@ class IsIn(ElemWise):
     dshape("10 * bool")
     """
     _arguments = '_child', '_keys'
+    _input_attributes = '_child', '_keys'
 
     def _schema(self):
         return datashape.bool_
+
+    @property
+    def _name(self):
+        return self._child._name
 
     def __str__(self):
         return '%s.%s(%s)' % (self._child, type(self).__name__.lower(),
@@ -894,11 +899,9 @@ class IsIn(ElemWise):
 
 @copydoc(IsIn)
 def isin(expr, keys):
-    if isinstance(keys, Expr):
-        raise TypeError('keys argument cannot be an expression, '
-                        'it must be an iterable object such as a list, '
-                        'tuple or set')
-    return IsIn(expr, frozenset(keys))
+    if not isinstance(keys, Expr):
+        keys = literal(keys)
+    return IsIn(expr, keys)
 
 
 class Shift(Expr):

--- a/blaze/expr/tests/test_collections.py
+++ b/blaze/expr/tests/test_collections.py
@@ -250,11 +250,16 @@ def test_isin():
     assert not hasattr(a, 'isin')
 
 
-def test_isin_no_expressions():
+def test_isin_expressions():
     a = symbol('a', 'var * int')
     b = symbol('b', 'var * int')
-    with pytest.raises(TypeError):
-        a.isin(b)
+    assert a.isin(b).dshape == dshape('var * bool')
+
+
+def test_isin_literal():
+    a = symbol('a', 'var * int')
+    b = [1, 2, 3]
+    assert a.isin(b).dshape == dshape('var * bool')
 
 
 def test_concat_table():

--- a/blaze/server/tests/test_server.py
+++ b/blaze/server/tests/test_server.py
@@ -708,7 +708,7 @@ def test_isin_expr(test, serial):
     resp = serial.loads(result.data)
     assert list(serial.data_loads(resp['data'])) == expected['data']
     assert list(resp['names']) == expected['names']
-    assert resp['datashape'] == expected['datashape']
+    assert_dshape_equal(resp['datashape'], expected['datashape'])
 
 
 @pytest.mark.parametrize('serial', all_formats)

--- a/blaze/server/tests/test_server.py
+++ b/blaze/server/tests/test_server.py
@@ -694,6 +694,24 @@ def test_isin(test, serial):
 
 
 @pytest.mark.parametrize('serial', all_formats)
+def test_isin_expr(test, serial):
+    name_filter = t.accounts[t.accounts.amount > 100].name
+    expr = t.cities.name.isin(name_filter)
+    query = {'expr': to_tree(expr)}
+    result = test.post('/compute',
+                       headers=mimetype(serial),
+                       data=serial.dumps(query))
+    expected = {'data': [False, True],
+                'names': ['name'],
+                'datashape': '2 * bool'}
+    assert result.status_code == RC.OK
+    resp = serial.loads(result.data)
+    assert list(serial.data_loads(resp['data'])) == expected['data']
+    assert list(resp['names']) == expected['names']
+    assert resp['datashape'] == expected['datashape']
+
+
+@pytest.mark.parametrize('serial', all_formats)
 def test_add_errors(temp_add_server, serial):
     pre_datashape = datashape.dshape(temp_add_server
                                      .get('/datashape')


### PR DESCRIPTION
The goal is to support SQL IsIn statements which use a `SELECT` from another
table as the definition of the `IN` group.