### PR TITLE
Python 3.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ install:
   # pulling from master), this speeds up the builds a lot. Use the normal pip
   # install for the rest.
   - conda create -n odo numpy=1.11.2
-  - conda create -n blaze -c blaze python=$TRAVIS_PYTHON_VERSION numpy=1.11.2 numba==0.29.0
+  - conda create -n blaze -c blaze python=$TRAVIS_PYTHON_VERSION numpy=1.11.2 numba==0.34.0
   - if [ -n "$PANDAS_VERSION" ]; then pip install cython==0.24.1; pip install $PANDAS_VERSION; else conda install pandas=0.19.0; fi
   - source activate blaze
   # update setuptools and pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,15 @@ matrix:
       env: SPARK_VERSION=1.5
     - python: 3.5
       env: SPARK_VERSION=1.5
+    - python: 3.6
+      env: SPARK_VERSION=1.5
     - python: 2.7
       env: PANDAS_VERSION="git+https://github.com/pydata/pandas" SPARK_VERSION=1.5
     - python: 3.4
       env: PANDAS_VERSION="git+https://github.com/pydata/pandas" SPARK_VERSION=1.5
     - python: 3.5
+      env: PANDAS_VERSION="git+https://github.com/pydata/pandas" SPARK_VERSION=1.5
+    - python: 3.6
       env: PANDAS_VERSION="git+https://github.com/pydata/pandas" SPARK_VERSION=1.5
   allow_failures:
     - python: 2.7
@@ -27,6 +31,8 @@ matrix:
     - python: 3.4
       env: PANDAS_VERSION="git+https://github.com/pydata/pandas" SPARK_VERSION=1.5
     - python: 3.5
+      env: PANDAS_VERSION="git+https://github.com/pydata/pandas" SPARK_VERSION=1.5
+    - python: 3.6
       env: PANDAS_VERSION="git+https://github.com/pydata/pandas" SPARK_VERSION=1.5
 
 services:

--- a/blaze/compute/dask.py
+++ b/blaze/compute/dask.py
@@ -39,7 +39,8 @@ try:
         func = get_numba_ufunc(expr)
         return atop(func,
                     expr_inds,
-                    *concat((dat, tuple(range(ndim(dat))[::-1])) for dat in data))
+                    *concat((dat, tuple(range(ndim(dat))[::-1])) for dat in data),
+                    dtype=data[-1].dtype)
 
     def optimize_array(expr, *data):
         return broadcast_collect(

--- a/blaze/server/serialization/serialization.py
+++ b/blaze/server/serialization/serialization.py
@@ -13,7 +13,10 @@ from pandas.io.packers import (
     decode as pd_msgpack_object_hook,
     encode as pd_msgpack_default,
 )
-import pandas.msgpack as msgpack_module
+try:
+    import pandas.msgpack as msgpack_module
+except ImportError:
+    import pandas.io.msgpack as msgpack_module
 from toolz import identity
 
 from blaze.compatibility import pickle as pickle_module, unicode, PY2

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -17,7 +17,6 @@ requirements:
     - python
     - setuptools
     - contextlib2 # [py2k]
-    - dask
     - flask >=0.10.1
     - flask-cors
     - odo >=0.5.0
@@ -29,7 +28,6 @@ requirements:
     - python
     - contextlib2 # [py2k]
     - cytoolz
-    - dask
     - flask >=0.10.1
     - flask-cors
     - h5py

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - numba
     - odo >=0.5.0
     - datashape >=0.5.3
-    - psutil ==4.0
+    - psutil
     - pytables >=3.0.0
     - pyyaml
     - requests

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - flask-cors
     - odo >=0.5.0
     - datashape >=0.5.3
-    - psutil ==4.0
+    - psutil
     - sqlalchemy >=0.8.0
     - toolz
   run:


### PR DESCRIPTION
This PR removes the pinned version of psutil. That is the only thing blocking 3.6 versions from being built.

Resolves #1650 