### PR TITLE
TST: Fix failing datetime access tests.

### DIFF
--- a/blaze/compute/tests/test_postgresql_compute.py
+++ b/blaze/compute/tests/test_postgresql_compute.py
@@ -867,23 +867,26 @@ def test_selection_selectable(sql):
 
 
 @pytest.mark.parametrize(
-    'attr', (
-        'day',
-        'month',
-        'week',
-        'minute',
-        'second',
-        'dayofweek',
-        'weekday',
-        'dayofyear',
-        'quarter',
+    'attr,dtype', (
+        ('day', np.int64),
+        ('month', np.int64),
+        ('week', np.int16),
+        ('minute', np.int64),
+        ('second', np.int64),
+        ('dayofweek', np.int16),
+        ('weekday', np.int16),
+        ('dayofyear', np.int16),
+        ('quarter', np.int16),
     ),
 )
-def test_datetime_access(attr, sql_with_dts):
+def test_datetime_access(attr, dtype, sql_with_dts):
     s = symbol('s', discover(sql_with_dts))
     expr = getattr(s.A.dt, attr)()
+    result = compute(expr, sql_with_dts, return_type=pd.Series)
+    assert result.dtype == dtype
     assert_series_equal(
-        compute(expr, sql_with_dts, return_type=pd.Series),
+        result,
         getattr(compute(s.A, sql_with_dts, return_type=pd.Series).dt, attr),
         check_names=False,
+        check_dtype=False,
     )


### PR DESCRIPTION
The results of the expressions compared in the test_datetime_access test do not
share the same dtype.

The computation which does the attribute lookup as part of the expression uses
the dtypes specified in `blaze.expr.datetime`.

The computation which does not do the attribute lookup returns a
`DatetimeProperties` instance; attribute lookups on those instances are all
`int64`.

Fix by setting the check dtype flag to `False`.

Add expected dtypes to the tests fixture and assert that the computation which
does the attribute lookup returns the correct type.