### PR TITLE
DOC: Fixed typo in the schema of orders example

### DIFF
--- a/docs/source/sql.rst
+++ b/docs/source/sql.rst
@@ -139,7 +139,7 @@ and an ``orders`` table with this schema:
 
      create table orders (
          id integer primary key,
-         product_id integer references (id) products,
+         product_id integer references products(id),
          quantity integer
      )
 


### PR DESCRIPTION
Corrected the mistake in the schema of the orders table in the products/orders example.