### PR TITLE
Import ABC from collections.abc instead of collections for Python 3.9 compatibility

### DIFF
--- a/blaze/compatibility.py
+++ b/blaze/compatibility.py
@@ -143,3 +143,9 @@ if PY2:
         return cs.decode('utf-8')
 else:
     u8 = identity
+
+
+if PY3:
+    import collections.abc as collections_abc
+else:
+    import collections as collections_abc

--- a/blaze/compute/bcolz.py
+++ b/blaze/compute/bcolz.py
@@ -5,6 +5,7 @@ from weakref import WeakKeyDictionary
 from toolz import curry, concat, first, memoize
 from multipledispatch import MDNotImplementedError
 
+from ..compatibility import collections_abc
 from ..expr import (
     Distinct,
     ElemWise,
@@ -23,7 +24,6 @@ from ..partition import partitions
 from .core import compute
 from .pmap import get_default_pmap
 
-from collections import Iterator, Iterable
 import datashape
 import bcolz
 import numpy as np
@@ -106,7 +106,7 @@ def compute_down(expr, data, **kwargs):
         val = data.value
         return compute(
             expr,
-            {leaf: into(Iterator, val)},
+            {leaf: into(collections_abc.Iterator, val)},
             return_type='native',
             **kwargs
         )
@@ -177,7 +177,7 @@ def compute_down(expr, data, chunksize=None, map=None, **kwargs):
         intermediate = np.concatenate(parts)
     elif isinstance(parts[0], pd.DataFrame):
         intermediate = pd.concat(parts)
-    elif isinstance(parts[0], Iterable):
+    elif isinstance(parts[0], collections_abc.Iterable):
         intermediate = list(concat(parts))
     else:
         raise TypeError("Don't know how to concatenate objects of type %r" %
@@ -192,7 +192,7 @@ def _asarray(a):
     return np.array(list(a))
 
 
-@compute_down.register(Expr, (box(bcolz.carray), box(bcolz.ctable)), Iterable)
+@compute_down.register(Expr, (box(bcolz.carray), box(bcolz.ctable)), collections_abc.Iterable)
 @compute_down.register(Expr, Iterable, (box(bcolz.carray), box(bcolz.ctable)))
 def bcolz_mixed(expr, a, b, **kwargs):
     return compute(

--- a/blaze/compute/chunks.py
+++ b/blaze/compute/chunks.py
@@ -2,13 +2,13 @@ from __future__ import absolute_import, division, print_function
 
 from multipledispatch import MDNotImplementedError
 from odo import Chunks, convert, into
-from collections import Iterator, Iterable
 from toolz import curry, concat
 from datashape.dispatch import dispatch
 
 import pandas as pd
 import numpy as np
 
+from ..compatibility import collections_abc
 from ..expr import Head, ElemWise, Distinct, Symbol, Expr, path
 from ..expr.split import split
 from .core import compute
@@ -49,7 +49,7 @@ def compute_down(expr, data, map=None, **kwargs):
         intermediate = np.concatenate(parts)
     elif isinstance(parts[0], pd.DataFrame):
         intermediate = pd.concat(parts)
-    elif isinstance(parts[0], (Iterable, Iterator)):
+    elif isinstance(parts[0], (collections_abc.Iterable, collections_abc.Iterator)):
         intermediate = list(concat(parts))
 
     return compute(agg_expr, {agg: intermediate})

--- a/blaze/compute/core.py
+++ b/blaze/compute/core.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from collections import defaultdict, Iterator, Mapping
+from collections import defaultdict
 import decimal
 from datetime import date, datetime, timedelta
 from functools import partial
@@ -23,7 +23,7 @@ import toolz
 from toolz import first, unique, assoc
 from toolz.utils import no_default
 
-from ..compatibility import basestring
+from ..compatibility import collections_abc, basestring
 from ..expr import (
     BoundSymbol,
     Cast,
@@ -98,9 +98,9 @@ def issubtype(a, b):
     """ A custom issubclass """
     if issubclass(a, b):
         return True
-    if issubclass(a, (tuple, list, set)) and issubclass(b, Iterator):
+    if issubclass(a, (tuple, list, set)) and issubclass(b, collections_abc.Iterator):
         return True
-    if issubclass(b, (tuple, list, set)) and issubclass(a, Iterator):
+    if issubclass(b, (tuple, list, set)) and issubclass(a, collections_abc.Iterator):
         return True
     return False
 
@@ -379,7 +379,7 @@ def into(a, b, **kwargs):
     return into(a, result, **kwargs)
 
 
-Expr.__iter__ = into(Iterator)
+Expr.__iter__ = into(collections_abc.Iterator)
 
 
 @dispatch(Expr)
@@ -391,7 +391,7 @@ def compute(expr, **kwargs):
         return compute(expr, resources, **kwargs)
 
 
-@dispatch(Expr, Mapping)
+@dispatch(Expr, collections_abc.Mapping)
 def compute(expr, d, return_type=no_default, **kwargs):
     """Compute expression against data sources.
 
@@ -492,7 +492,7 @@ def compute_single_object(expr, o, **kwargs):
         raise ValueError("Give compute dictionary input, got %s" % str(o))
 
 
-@dispatch(Field, Mapping)
+@dispatch(Field, collections_abc.Mapping)
 def compute_up(expr, data, **kwargs):
     return data[expr._name]
 

--- a/blaze/compute/csv.py
+++ b/blaze/compute/csv.py
@@ -5,13 +5,13 @@ import os
 from toolz import curry, concat
 import pandas as pd
 import numpy as np
-from collections import Iterator, Iterable
 from odo import into, Temp
 from odo.backends.csv import CSV
 from odo.backends.url import URL
 from multipledispatch import MDNotImplementedError
 import dask.dataframe as dd
 
+from ..compatibility import collections_abc
 from ..dispatch import dispatch
 from ..expr import Expr, Head, ElemWise, Distinct, Symbol, Projection, Field
 from ..expr.core import path
@@ -74,6 +74,6 @@ Cheap = (Head, ElemWise, Distinct, Symbol)
 def pre_compute(expr, data, **kwargs):
     leaf = expr._leaves()[0]
     if all(isinstance(e, Cheap) for e in path(expr, leaf)):
-        return into(Iterator, data, chunksize=10000, dshape=leaf.dshape)
+        return into(collections_abc.Iterator, data, chunksize=10000, dshape=leaf.dshape)
     else:
         raise MDNotImplementedError()

--- a/blaze/compute/json.py
+++ b/blaze/compute/json.py
@@ -1,9 +1,9 @@
 from .core import pre_compute
+from ..compatibility import collections_abc
 from ..dispatch import dispatch
 from ..expr import Expr
 from odo.backends.json import JSON, JSONLines
 from odo import into
-from collections import Iterator
 from odo.utils import records_to_tuples
 
 
@@ -19,6 +19,6 @@ def pre_compute(expr, data, **kwargs):
 
 @dispatch(Expr, JSONLines)
 def pre_compute(expr, data, **kwargs):
-    seq = into(Iterator, data, **kwargs)
+    seq = into(collections_abc.Iterator, data, **kwargs)
     leaf = expr._leaves()[0]
     return records_to_tuples(leaf.dshape, seq)

--- a/blaze/compute/numpy.py
+++ b/blaze/compute/numpy.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-from collections import Iterable
 import datetime
 
 import numpy as np
@@ -10,6 +9,7 @@ from numbers import Number
 
 from odo import odo
 
+from ..compatibility import collections_abc
 from ..expr import (
     Reduction, Field, Projection, Broadcast, Selection, ndim,
     Distinct, Sort, Tail, Head, Label, ReLabel, Expr, Slice, Join,
@@ -436,7 +436,7 @@ def compute_up(expr, lhs, rhs, **kwargs):
     return np.tensordot(lhs, rhs, axes=[expr._left_axes, expr._right_axes])
 
 
-@dispatch(IsIn, np.ndarray, Iterable)
+@dispatch(IsIn, np.ndarray, collections_abc.Iterable)
 def compute_up(expr, data, keys, **kwargs):
     return np.in1d(data, keys)
 

--- a/blaze/compute/pandas.py
+++ b/blaze/compute/pandas.py
@@ -21,7 +21,7 @@ import fnmatch
 import itertools
 from distutils.version import LooseVersion
 import warnings
-from collections import defaultdict, Iterable
+from collections import defaultdict
 
 import numpy as np
 
@@ -52,7 +52,7 @@ except ImportError:
 
 from .core import compute, compute_up, base
 from .varargs import VarArgs
-from ..compatibility import _inttypes
+from ..compatibility import collections_abc, _inttypes
 from ..dispatch import dispatch
 from ..expr import (
     Apply,
@@ -847,7 +847,7 @@ def compute_up(expr, data, **kwargs):
                   name=expr._name)
 
 
-@dispatch(IsIn, (Series, DaskSeries), Iterable)
+@dispatch(IsIn, (Series, DaskSeries), collections_abc.Iterable)
 def compute_up(expr, data, keys, **kwargs):
     return data.isin(keys)
 

--- a/blaze/compute/python.py
+++ b/blaze/compute/python.py
@@ -11,7 +11,7 @@
 """
 from __future__ import absolute_import, division, print_function
 
-from collections import Iterable, Mapping
+
 import itertools
 import numbers
 import fnmatch
@@ -21,7 +21,6 @@ import math
 import random
 from uuid import uuid4
 
-from collections import Iterator
 from functools import partial
 
 from datashape import Option, to_numpy_dtype, discover
@@ -38,6 +37,7 @@ except ImportError:
     from toolz import groupby, reduceby, unique, take, concat, nth, pluck
 
 
+from ..compatibility import collections_abc
 from ..dispatch import dispatch
 from ..expr import (Projection, Field, Broadcast, Map, Label, ReLabel,
                     Merge, Join, Selection, Reduction, Distinct,
@@ -103,20 +103,20 @@ from math import (
 
 __all__ = ['compute', 'compute_up', 'Sequence', 'rowfunc', 'rrowfunc']
 
-Sequence = (tuple, list, Iterator, type(dict().items()))
+Sequence = (tuple, list, collections_abc.Iterator, type(dict().items()))
 
 
 @dispatch(Expr, Sequence)
 def pre_compute(expr, seq, scope=None, **kwargs):
     try:
-        if isinstance(seq, Iterator):
+        if isinstance(seq, collections_abc.Iterator):
             first = next(seq)
             seq = concat([[first], seq])
         else:
             first = next(iter(seq))
     except StopIteration:
         return []
-    if isinstance(first, Mapping):
+    if isinstance(first, collections_abc.Mapping):
         leaf = expr._leaves()[0]
         return pluck(leaf.fields, seq)
     else:
@@ -732,7 +732,7 @@ def compute_up(t, seq, **kwargs):
 def compute_up(expr, data, **kwargs):
     if expr._child.ndim != 1:
         raise NotImplementedError('Only 1D reductions currently supported')
-    if isinstance(data, Iterator):
+    if isinstance(data, collections_abc.Iterator):
         datas = itertools.tee(data, len(expr.values))
         result = tuple(
             compute(val, {expr._child: data}, return_type='native')

--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -17,7 +17,6 @@ WHERE accounts.amount < :amount_1
 
 from __future__ import absolute_import, division, print_function
 
-from collections import Iterable
 from copy import copy
 import datetime
 import itertools
@@ -45,7 +44,7 @@ from toolz.curried import map
 
 from .core import compute_up, compute, base
 from .varargs import VarArgs
-from ..compatibility import reduce, basestring, _inttypes
+from ..compatibility import collections_abc, reduce, basestring, _inttypes
 from ..dispatch import dispatch
 from ..expr import (
     BinOp,
@@ -1566,7 +1565,7 @@ def post_compute(_, s, **kwargs):
     return select(s)
 
 
-@dispatch((Iterable, Selectable))
+@dispatch((collections_abc.Iterable, Selectable))
 def _coerce_op_input(i):
     """Make input to SQLAlchemy operator an amenable type.
 
@@ -1601,12 +1600,12 @@ def _coerce_op_input(i):
     return select(i)
 
 
-@dispatch(IsIn, ColumnElement, (Iterable, Selectable, ColumnElement))
+@dispatch(IsIn, ColumnElement, (collections_abc.Iterable, Selectable, ColumnElement))
 def compute_up(expr, data, keys, **kwargs):
     return data.in_(_coerce_op_input(keys))
 
 
-@dispatch(IsIn, Selectable, (Iterable, Selectable, ColumnElement))
+@dispatch(IsIn, Selectable, (collections_abc.Iterable, Selectable, ColumnElement))
 def compute_up(expr, data, keys, **kwargs):
     assert len(data.columns) == 1, (
         'only 1 column is allowed in a Select in IsIn'

--- a/blaze/compute/tests/test_csv_compute.py
+++ b/blaze/compute/tests/test_csv_compute.py
@@ -1,5 +1,6 @@
 from blaze.compute.csv import pre_compute, CSV
 from blaze import compute, discover, dshape, into, join, concat, data
+from blaze.compatibility import collections_abc
 from blaze.utils import example, filetext, filetexts
 from blaze.expr import symbol
 from pandas import DataFrame, Series
@@ -8,7 +9,6 @@ from datashape.predicates import iscollection
 import numpy as np
 import pandas as pd
 from toolz import first
-from collections import Iterator
 from odo import odo
 from odo.chunks import chunks
 import dask.dataframe
@@ -30,7 +30,7 @@ def test_pre_compute_with_head_on_large_csv_yields_iterator():
     csv = CSV(example('iris.csv'))
     s = symbol('s', discover(csv))
     assert isinstance(pre_compute(s.species.head(), csv, comfortable_memory=10),
-                      Iterator)
+                      collections_abc.Iterator)
 
 
 def test_compute_chunks_on_single_csv():

--- a/blaze/compute/tests/test_python_compute.py
+++ b/blaze/compute/tests/test_python_compute.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import, division, print_function
-from collections import Mapping
 
 import math
 import itertools
@@ -8,13 +7,12 @@ import pytest
 from datetime import datetime, date
 import datashape
 from datashape.py2help import mappingproxy
-from collections import Iterator, Iterable
 
 import blaze
 from blaze.compute.python import (nunique, mean, rrowfunc, rowfunc,
                                   reduce_by_funcs, optimize)
 from blaze import dshape, symbol, discover
-from blaze.compatibility import PY2
+from blaze.compatibility import collections_abc, PY2
 from blaze.compute.core import compute, compute_up, pre_compute
 from blaze.expr import (by, merge, join, distinct, sum, min, max, any, summary,
                         count, std, head, sample, transform, greatest, least)
@@ -771,9 +769,9 @@ def test_multi_dataset_broadcast_with_Record_types():
 
 
 def eq(a, b):
-    if isinstance(a, (Iterable, Iterator)):
+    if isinstance(a, (collections_abc.Iterable, collections_abc.Iterator)):
         a = list(a)
-    if isinstance(b, (Iterable, Iterator)):
+    if isinstance(b, (collections_abc.Iterable, collections_abc.Iterator)):
         b = list(b)
     return a == b
 
@@ -837,7 +835,7 @@ def test_compute_field_on_dicts():
     assert compute(s.x, {s: d}) == [1, 2, 3]
 
 
-class _MapProxy(Mapping):  # pragma: no cover
+class _MapProxy(collections_abc.Mapping):  # pragma: no cover
     def __init__(self, mapping):
         self._map = mapping
 

--- a/blaze/expr/arrays.py
+++ b/blaze/expr/arrays.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import, division, print_function
 
-from collections import Iterable
 
 from datashape import DataShape
 from odo.utils import copydoc
 
+from ..compatibility import collections_abc
 from .expressions import Expr, ndim, symbol
 
 __all__ = 'Transpose', 'TensorDot', 'dot', 'transpose', 'tensordot'
@@ -107,7 +107,7 @@ def tensordot(lhs, rhs, axes=None):
     if axes is None:
         left = ndim(lhs) - 1
         right = 0
-    elif isinstance(axes, Iterable):
+    elif isinstance(axes, collections_abc.Iterable):
         left, right = axes
     else:
         left, right = axes, axes

--- a/blaze/expr/core.py
+++ b/blaze/expr/core.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from collections import Mapping, OrderedDict
+from collections import OrderedDict
 import datetime
 from functools import reduce, partial
 import inspect
@@ -13,7 +13,7 @@ from weakref import WeakValueDictionary
 import toolz
 from toolz import unique, concat, first
 
-from ..compatibility import _strtypes
+from ..compatibility import collections_abc, _strtypes
 from ..dispatch import dispatch
 from ..utils import ordered_intersect
 
@@ -426,12 +426,12 @@ def subs(o, d):
     return _subs(o, d)
 
 
-@dispatch((tuple, list), Mapping)
+@dispatch((tuple, list), collections_abc.Mapping)
 def _subs(o, d):
     return type(o)(subs(arg, d) for arg in o)
 
 
-@dispatch(Node, Mapping)
+@dispatch(Node, collections_abc.Mapping)
 def _subs(o, d):
     """
 
@@ -444,7 +444,7 @@ def _subs(o, d):
     return type(o)(*newargs)
 
 
-@dispatch(object, Mapping)
+@dispatch(object, collections_abc.Mapping)
 def _subs(o, d):
     """ Private dispatched version of ``subs``
 

--- a/blaze/expr/expressions.py
+++ b/blaze/expr/expressions.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-from collections import Mapping
 from keyword import iskeyword
 import re
 
@@ -28,7 +27,7 @@ import toolz
 from toolz import concat, memoize, partial, first, unique, merge
 from toolz.curried import map, filter
 
-from ..compatibility import _strtypes, builtins, boundmethod, PY2
+from ..compatibility import collections_abc, _strtypes, builtins, boundmethod, PY2
 from .core import (
     Node,
     _setattr,
@@ -338,7 +337,7 @@ def symbol(name, dshape, token=None):
     return Symbol(name, datashape.dshape(dshape), token or 0)
 
 
-@dispatch(Symbol, Mapping)
+@dispatch(Symbol, collections_abc.Mapping)
 def _subs(o, d):
     """ Subs symbols using symbol function
 
@@ -682,7 +681,7 @@ def relabel(child, labels=None, **kwargs):
                          ', '.join(map(repr, non_existent_fields)))
     if not labels:
         return child
-    if isinstance(labels, Mapping):  # Turn dict into tuples
+    if isinstance(labels, collections_abc.Mapping):  # Turn dict into tuples
         labels = tuple(sorted(labels.items()))
     if isscalar(child.dshape.measure):
         if child._name == labels[0][0]:

--- a/blaze/expr/literal.py
+++ b/blaze/expr/literal.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-from collections import Iterator, Mapping
 import itertools
 
 import datashape
@@ -13,7 +12,7 @@ from datashape.predicates import (
 from odo import resource
 from odo.utils import ignoring, copydoc
 
-from ..compatibility import _strtypes
+from ..compatibility import collections_abc, _strtypes
 from ..dispatch import dispatch
 from .expressions import sanitized_dshape, Symbol
 
@@ -158,7 +157,7 @@ def _bound_symbol(cls,
             **kwargs
         )
 
-    if (isinstance(data_source, Iterator) and
+    if (isinstance(data_source, collections_abc.Iterator) and
             not isinstance(data_source, tuple(not_an_iterator))):
         data_source = tuple(data_source)
 
@@ -243,6 +242,6 @@ def data(data_source,
     )
 
 
-@dispatch(BoundSymbol, Mapping)
+@dispatch(BoundSymbol, collections_abc.Mapping)
 def _subs(o, d):
     return o

--- a/blaze/server/serialization/json_dumps_trusted.py
+++ b/blaze/server/serialization/json_dumps_trusted.py
@@ -1,9 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
-from collections import Callable
 
 from blaze.dispatch import dispatch
-from blaze.compatibility import u8
+from blaze.compatibility import collections_abc, u8
 from functools import partial
 
 from .json_dumps import json_dumps
@@ -13,7 +12,7 @@ json_dumps_trusted_ns = dict()
 dispatch = partial(dispatch, namespace=json_dumps_trusted_ns)
 
 
-@dispatch(Callable)
+@dispatch(collections_abc.Callable)
 def json_dumps_trusted(f):
     # let the server serialize any callable - this is only used for testing
     # at present - do the error handling when json comes from client so in

--- a/blaze/server/server.py
+++ b/blaze/server/server.py
@@ -5,7 +5,6 @@ import logging
 from logging import Formatter
 from functools import wraps
 import traceback
-import collections
 from datetime import datetime
 import errno
 import functools
@@ -26,7 +25,7 @@ from toolz import valmap, compose
 import blaze
 import blaze as bz
 from blaze import compute, resource
-from blaze.compatibility import ExitStack, u8
+from blaze.compatibility import collections_abc, ExitStack, u8
 from blaze.compute import compute_up
 from .serialization import json, all_formats
 from ..expr import (
@@ -341,7 +340,7 @@ class Server(object):
                  logfile=sys.stdout,
                  loglevel='WARNING',
                  log_exception_formatter=_default_log_exception_formatter):
-        if isinstance(data, collections.Mapping):
+        if isinstance(data, collections_abc.Mapping):
             data = valmap(lambda v: v.data if isinstance(v, BoundSymbol) else v,
                           data)
         elif isinstance(data, BoundSymbol):
@@ -700,13 +699,13 @@ def addserver(payload, serial):
 
     data = _get_data.cache[flask.current_app]
 
-    if not isinstance(data, collections.MutableMapping):
+    if not isinstance(data, collections_abc.MutableMapping):
         data_not_mm_msg = ("Cannot update blaze server data since its current "
                            "data is a %s and not a mutable mapping (dictionary "
                            "like).")
         return (data_not_mm_msg % type(data), RC.UNPROCESSABLE_ENTITY)
 
-    if not isinstance(payload, collections.Mapping):
+    if not isinstance(payload, collections_abc.Mapping):
         payload_not_mm_msg = ("Need a dictionary-like payload; instead was "
                               "given %s of type %s.")
         return (payload_not_mm_msg % (payload, type(payload)),

--- a/blaze/tests/test_cached.py
+++ b/blaze/tests/test_cached.py
@@ -1,7 +1,7 @@
+from blaze.compatibility import collections_abc
 from blaze.cached import CachedDataset
 from blaze import symbol, discover, compute, into
 import pandas as pd
-from collections import Iterator
 
 
 df = pd.DataFrame([['Alice', 100, 1],
@@ -36,5 +36,5 @@ def test_streaming():
     expr = s.t.x * 2
     result = compute(expr, d)
 
-    assert not isinstance(d.cache[expr], Iterator)
+    assert not isinstance(d.cache[expr], collections_abc.Iterator)
     assert into(list, d.cache[expr]) == [2, 2]

--- a/blaze/utils.py
+++ b/blaze/utils.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 import datetime
-from collections import Iterator
 from itertools import islice, product
 import os
 import re
@@ -20,7 +19,7 @@ import sqlalchemy as sa
 from toolz.curried import do
 
 # Imports that replace older utils.
-from .compatibility import map, zip
+from .compatibility import collections_abc, map, zip
 
 
 def nth_list(n, seq):
@@ -68,11 +67,11 @@ def get(ind, coll, lazy=False):
     elif isinstance(ind, slice):
         result = islice(coll, ind.start, ind.stop, ind.step)
     else:
-        if isinstance(coll, Iterator):
+        if isinstance(coll, collections_abc.Iterator):
             result = nth(ind, coll)
         else:
             result = coll[ind]
-    if not lazy and isinstance(result, Iterator):
+    if not lazy and isinstance(result, collections_abc.Iterator):
         result = tuple(result)
     return result
 


### PR DESCRIPTION
Fixes #1689 . Any other instances found during review that I missed in my regex can also be fixed. 