### PR TITLE
Remove undefined names

### DIFF
--- a/blaze/expr/math.py
+++ b/blaze/expr/math.py
@@ -10,11 +10,7 @@ from ..compatibility import builtins
 # Here follows a large number of unary operators.  These were selected by
 # taking the intersection of the functions in ``math`` and ``numpy``
 
-__all__ = ['abs', 'sqrt', 'sin', 'sinh', 'cos', 'cosh', 'tan', 'tanh', 'exp',
-           'expm1', 'log', 'log10', 'log1p', 'acos', 'acosh', 'asin', 'asinh',
-           'atan', 'atanh', 'radians', 'degrees', 'atan2', 'ceil', 'floor',
-           'trunc', 'isnan', 'notnull', 'UnaryMath', 'BinaryMath',
-           'greatest', 'least']
+__all__ = ['isnan', 'notnull', 'UnaryMath', 'BinaryMath', 'greatest', 'least']
 
 
 class UnaryMath(UnaryOp):


### PR DESCRIPTION
In file: math.py, the list named __all__ contains undefined names which can result in errors when this module is imported. iCR removed the undefined names from the list. For more information regarding __all__, please read about importing fields from a package. 

**Sponsorship and Support:**

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.